### PR TITLE
feat(installed): install mods dragged from the file explorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to Modrex are documented in this file. Each version's sectio
 - Browse now lets you filter mods by tag, choosing tags to include or exclude.
 - New Storage section in Settings to clear cached data and reset app settings to defaults.
 - New buttons in Settings to open the game folder, each of its mod folders, and Modrex's data and install folders.
+- Mods can now be installed by dragging files from the file explorer into the window.
 
 ### Changed
 

--- a/src-tauri/src/commands/mods/mod.rs
+++ b/src-tauri/src/commands/mods/mod.rs
@@ -739,16 +739,31 @@ pub async fn install_dropped_file(
             let _ = std::fs::remove_file(&zip_path);
             return result;
         }
-        // Part 2b routes these to the archive picker / sentinel modals; until then a dropped
-        // multi-pak or specially-packaged archive is reported plainly rather than mis-installed.
+        // The picker / host-pack / CB-flat modals install directly from the temp copy (which they
+        // delete afterwards), so forward the sentinel enriched with a synthetic identity, mirroring
+        // install_file. get_installed reconciles the resulting entries by SHA256 on the next refresh.
+        // UNRECOGNIZED_ARCHIVE is intentionally not forwarded — its modal fetches a modworkshop mod
+        // page a local file has no id for — so it falls through to the plain-error arm below.
         Err(e)
             if e.starts_with("ZIP_MULTI_PAK:")
                 || e.starts_with("HOST_MOD_PACK:")
-                || e.starts_with("CB_FLAT_ARCHIVE:")
-                || e.starts_with("UNRECOGNIZED_ARCHIVE") =>
+                || e.starts_with("CB_FLAT_ARCHIVE:") =>
         {
-            let _ = tokio::fs::remove_file(&temp).await;
-            return Err("DROP_NEEDS_PICKER".to_string());
+            let prefix = e
+                .split_once(':')
+                .map(|(p, _)| format!("{p}:"))
+                .unwrap_or_default();
+            if let Ok(mut v) = serde_json::from_str::<serde_json::Value>(&e[prefix.len()..]) {
+                let syn = hash_filename(&file_stem);
+                v["modId"] = serde_json::json!(syn);
+                v["modName"] = serde_json::json!(&file_stem);
+                v["fileId"] = serde_json::json!(syn);
+                v["fileType"] =
+                    serde_json::json!(src.extension().and_then(|s| s.to_str()).unwrap_or("zip"));
+                v["modVersion"] = serde_json::json!("unknown");
+                return Err(format!("{}{}", prefix, v));
+            }
+            return Err(e);
         }
         result => match result {
             Ok(v) => v,

--- a/src-tauri/src/commands/mods/mod.rs
+++ b/src-tauri/src/commands/mods/mod.rs
@@ -695,6 +695,165 @@ pub async fn install_file(
     result
 }
 
+/// Installs a mod from a local file the user dropped onto the window (Explorer drag-drop).
+/// The file carries no modworkshop identity, so it is installed as an unidentified entry
+/// (negative id, "unknown" version) exactly like an ambiently-discovered pak — `get_installed`'s
+/// SHA256 upgrade resolves its real identity on the next refresh. The dropped file is copied into
+/// temp first so resolution/cleanup never touches the user's original.
+#[tauri::command]
+pub async fn install_dropped_file(
+    app: AppHandle,
+    path: String,
+    game_path: String,
+    folder_id: Option<String>,
+    game_id: Option<String>,
+) -> Result<(), String> {
+    let cfg = engine_for_game(game_id.as_deref().unwrap_or("pd3"));
+    let src = PathBuf::from(&path);
+    let file_stem = src
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .map(|s| s.to_string())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| "invalid file name".to_string())?;
+
+    let temp = std::env::temp_dir().join(match src.extension().and_then(|s| s.to_str()) {
+        Some(ext) => format!("modrex-drop-{}.{}", Uuid::new_v4(), ext),
+        None => format!("modrex-drop-{}", Uuid::new_v4()),
+    });
+    tokio::fs::copy(&src, &temp)
+        .await
+        .map_err(|e| format!("could not read dropped file: {e}"))?;
+
+    let (tmp, zip_orig, location_tag) = match resolve_archive_download(temp.clone(), cfg) {
+        Err(e) if e.starts_with("UE4SS_LOADER:") => {
+            let zip_path = PathBuf::from(&e["UE4SS_LOADER:".len()..]);
+            let settings = read_settings(&app);
+            let launcher = game_settings(&settings, cfg.game_id).and_then(|gs| gs.launcher.clone());
+            let result = crate::commands::ue4ss::install_loader(
+                cfg.game_id,
+                &game_path,
+                launcher.as_deref(),
+                &zip_path,
+            );
+            let _ = std::fs::remove_file(&zip_path);
+            return result;
+        }
+        // Part 2b routes these to the archive picker / sentinel modals; until then a dropped
+        // multi-pak or specially-packaged archive is reported plainly rather than mis-installed.
+        Err(e)
+            if e.starts_with("ZIP_MULTI_PAK:")
+                || e.starts_with("HOST_MOD_PACK:")
+                || e.starts_with("CB_FLAT_ARCHIVE:")
+                || e.starts_with("UNRECOGNIZED_ARCHIVE") =>
+        {
+            let _ = tokio::fs::remove_file(&temp).await;
+            return Err("DROP_NEEDS_PICKER".to_string());
+        }
+        result => match result {
+            Ok(v) => v,
+            Err(e) => {
+                let _ = tokio::fs::remove_file(&temp).await;
+                log::warn!("install_dropped_file {path}: {e}");
+                return Err(e);
+            }
+        },
+    };
+    let target = cfg.target_for(location_tag.as_deref());
+
+    let result = async {
+        let sha256 = match &target.unit {
+            engine::ModUnit::File { .. } => compute_sha256(&tmp).await?,
+            engine::ModUnit::Directory { entry_markers, .. } => {
+                let hash_path = if entry_markers.is_empty() {
+                    hashable_file_for_mod_dir(&tmp)
+                        .ok_or_else(|| "mod directory is empty".to_string())?
+                } else {
+                    entry_markers
+                        .iter()
+                        .map(|m| tmp.join(m))
+                        .find(|p| p.exists())
+                        .unwrap_or_else(|| tmp.join(entry_markers[0]))
+                };
+                compute_sha256(&hash_path).await?
+            }
+        };
+        // Discovery-matching identity: filename drives the uid/id the untracked-scan would assign,
+        // so a later manual refresh reconciles this entry instead of duplicating it.
+        let filename = match &target.unit {
+            engine::ModUnit::File { .. } => pak_filename(&file_stem),
+            engine::ModUnit::Directory { .. } if cfg.game_id == "cb" => {
+                naming::mod_folder_name(&file_stem)
+            }
+            engine::ModUnit::Directory { .. } => tmp
+                .file_name()
+                .and_then(|s| s.to_str())
+                .unwrap_or(&file_stem)
+                .to_string(),
+        };
+        let uid = strip_priority_prefix(&filename).to_string();
+        let id = hash_filename(&filename);
+        let sp = get_state_path(&game_path, cfg);
+
+        install_mod_from_path(
+            &game_path,
+            &sp,
+            InstalledMod {
+                uid,
+                id,
+                name: file_stem.clone(),
+                version: "unknown".to_string(),
+                filename,
+                enabled: true,
+                installed_at: Utc::now().to_rfc3339(),
+                sha256: Some(sha256),
+                ..InstalledMod::default()
+            },
+            &tmp,
+            folder_id,
+            cfg,
+            target,
+        )?;
+        Ok::<(), String>(())
+    }
+    .await;
+
+    match &target.unit {
+        engine::ModUnit::File { .. } => {
+            let _ = tokio::fs::remove_file(&tmp).await;
+            for ext in naming::PAK_SIDECAR_EXTENSIONS {
+                let _ = tokio::fs::remove_file(tmp.with_extension(ext)).await;
+            }
+        }
+        engine::ModUnit::Directory { .. } if cfg.game_id == "cb" => {
+            let _ = tokio::fs::remove_dir_all(&tmp).await;
+        }
+        engine::ModUnit::Directory { .. } => {
+            if let Some(parent) = tmp.parent() {
+                let _ = tokio::fs::remove_dir_all(parent).await;
+            }
+        }
+    }
+    if let Some(orig) = zip_orig {
+        let _ = tokio::fs::remove_file(&orig).await;
+    }
+    let _ = tokio::fs::remove_file(&temp).await;
+
+    match &result {
+        Ok(_) => crate::commands::analytics::track(
+            &app,
+            "mod_installed",
+            serde_json::json!({
+                "game": game_id.as_deref().unwrap_or("pd3"),
+                "mod_id": -1,
+                "format": "local",
+            }),
+        ),
+        Err(e) => log::warn!("install_dropped_file {path}: {e}"),
+    }
+    result
+}
+
 #[tauri::command]
 pub async fn install_from_zip_entry(
     app: AppHandle,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -90,6 +90,7 @@ pub fn run() {
             commands::mods::get_installed,
             commands::mods::install_mod,
             commands::mods::install_file,
+            commands::mods::install_dropped_file,
             commands::mods::install_from_zip_entry,
             commands::mods::install_cb_flat_archive,
             commands::mods::install_host_pack,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
                 "backgroundColor": "#131313",
                 "decorations": false,
                 "visible": false,
-                "dragDropEnabled": false
+                "dragDropEnabled": true
             },
             {
                 "label": "splash",

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -28,6 +28,9 @@ import { api, type StartupPhase } from './api'
 import { TelemetryConsentDialog } from './components/TelemetryConsentDialog'
 import { FileDropOverlay, FileDropStatus } from './components/FileDropOverlay'
 import { useFileDropInstall } from './hooks/useFileDropInstall'
+import { ZipPickerModal } from './components/ZipPickerModal'
+import { HostPackModal } from './components/HostPackModal'
+import { CrimeBossFlatArchiveModal } from './components/CrimeBossFlatArchiveModal'
 import { useModIdentificationTracking } from './lib/analytics/useModIdentificationTracking'
 import { getSettingsCache, setSettingsCache } from './settingsCache'
 import { Dialog } from './components/Dialog'
@@ -428,6 +431,8 @@ export default function App() {
         progress: dropProgress,
         result: dropResult,
         dismissResult,
+        sentinel: dropSentinel,
+        resolveSentinel,
     } = useFileDropInstall({
         gamePath,
         activeGame,
@@ -445,6 +450,34 @@ export default function App() {
                     gameName={GAMES[activeGame].name}
                 />
                 {dropResult && <FileDropStatus result={dropResult} onDismiss={dismissResult} />}
+                {dropSentinel?.kind === 'zip' && gamePath && (
+                    <ZipPickerModal
+                        payload={dropSentinel.payload}
+                        gamePath={gamePath}
+                        installedFiles={installed}
+                        gameId={activeGame}
+                        onRefreshInstalled={refreshInstalled}
+                        onClose={resolveSentinel}
+                    />
+                )}
+                {dropSentinel?.kind === 'host' && gamePath && (
+                    <HostPackModal
+                        payload={dropSentinel.payload}
+                        gamePath={gamePath}
+                        installed={installed}
+                        gameId={activeGame}
+                        onRefreshInstalled={refreshInstalled}
+                        onClose={resolveSentinel}
+                    />
+                )}
+                {dropSentinel?.kind === 'cb' && gamePath && (
+                    <CrimeBossFlatArchiveModal
+                        payload={dropSentinel.payload}
+                        gamePath={gamePath}
+                        onRefreshInstalled={refreshInstalled}
+                        onClose={resolveSentinel}
+                    />
+                )}
                 {navigator.userAgent.includes('Linux') && <ResizeHandles />}
                 <>
                     <TopBar

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -26,6 +26,8 @@ import { ResizeHandles } from './components/ResizeHandles'
 import { SupportPromptBanner } from './components/SupportPromptBanner'
 import { api, type StartupPhase } from './api'
 import { TelemetryConsentDialog } from './components/TelemetryConsentDialog'
+import { FileDropOverlay, FileDropStatus } from './components/FileDropOverlay'
+import { useFileDropInstall } from './hooks/useFileDropInstall'
 import { useModIdentificationTracking } from './lib/analytics/useModIdentificationTracking'
 import { getSettingsCache, setSettingsCache } from './settingsCache'
 import { Dialog } from './components/Dialog'
@@ -420,9 +422,29 @@ export default function App() {
             ? prevView
             : (view as 'browse' | 'installed' | 'news' | 'settings')
 
+    const {
+        dragging: fileDragging,
+        installing: fileInstalling,
+        progress: dropProgress,
+        result: dropResult,
+        dismissResult,
+    } = useFileDropInstall({
+        gamePath,
+        activeGame,
+        enabled: view !== 'welcome',
+        onRefreshInstalled: refreshInstalled,
+    })
+
     return (
         <TooltipProvider delayDuration={400}>
             <div className="flex flex-col h-screen bg-surface text-text">
+                <FileDropOverlay
+                    active={fileDragging || fileInstalling}
+                    installing={fileInstalling}
+                    progress={dropProgress}
+                    gameName={GAMES[activeGame].name}
+                />
+                {dropResult && <FileDropStatus result={dropResult} onDismiss={dismissResult} />}
                 {navigator.userAgent.includes('Linux') && <ResizeHandles />}
                 <>
                     <TopBar

--- a/src/renderer/src/api.ts
+++ b/src/renderer/src/api.ts
@@ -1,6 +1,7 @@
 import { invoke } from '@tauri-apps/api/core'
 import { listen } from '@tauri-apps/api/event'
 import { getCurrentWindow } from '@tauri-apps/api/window'
+import { getCurrentWebview } from '@tauri-apps/api/webview'
 
 // The library declares this union without exporting it.
 export type ResizeDirection = Parameters<
@@ -213,6 +214,14 @@ export const api = {
     },
     installMod(modId: number, gamePath: string, gameId?: string): Promise<void> {
         return trackInstall(invoke('install_mod', { modId, gamePath, gameId }))
+    },
+    installDroppedFile(
+        path: string,
+        gamePath: string,
+        folderId?: string,
+        gameId?: string
+    ): Promise<void> {
+        return trackInstall(invoke('install_dropped_file', { path, gamePath, folderId, gameId }))
     },
     installModFile(
         modId: number,
@@ -498,6 +507,27 @@ export const api = {
     },
     onSupportPromptEligible(callback: () => void): () => void {
         return onEvent<void>('support-prompt:eligible', () => callback())
+    },
+    // Native OS file-drop paths (dragDropEnabled: true). 'enter'/'over' fire while files
+    // hover the window; 'drop' delivers the final absolute paths; 'leave' on cancel.
+    onFileDrop(
+        callback: (info: { type: 'enter' | 'over' | 'drop' | 'leave'; paths: string[] }) => void
+    ): () => void {
+        let unlistenFn: (() => void) | null = null
+        let cancelled = false
+        getCurrentWebview()
+            .onDragDropEvent((event) => {
+                const p = event.payload
+                callback({ type: p.type, paths: 'paths' in p ? p.paths : [] })
+            })
+            .then((fn) => {
+                if (cancelled) fn()
+                else unlistenFn = fn
+            })
+        return () => {
+            cancelled = true
+            unlistenFn?.()
+        }
     },
 
     // ── Thumbnails ─────────────────────────────────────────────────────────────

--- a/src/renderer/src/components/FileDropOverlay.tsx
+++ b/src/renderer/src/components/FileDropOverlay.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useState } from 'react'
+import { PackagePlus, CircleCheck, CircleAlert, Loader2, X } from 'lucide-react'
+import { t } from '../i18n'
+import type { DropResult } from '../hooks/useFileDropInstall'
+
+// Keeps children mounted through the exit transition: flips `shown` on the next frame
+// after mount (enter), and delays unmount by the transition duration on `active=false`.
+function useMountTransition(active: boolean, durationMs: number) {
+    const [render, setRender] = useState(active)
+    const [shown, setShown] = useState(false)
+    useEffect(() => {
+        if (active) {
+            setRender(true)
+            const id = requestAnimationFrame(() => setShown(true))
+            return () => cancelAnimationFrame(id)
+        }
+        setShown(false)
+        const timer = window.setTimeout(() => setRender(false), durationMs)
+        return () => window.clearTimeout(timer)
+    }, [active, durationMs])
+    return { render, shown }
+}
+
+export function FileDropOverlay({
+    active,
+    installing,
+    progress,
+    gameName,
+}: {
+    active: boolean
+    installing: boolean
+    progress: { current: number; total: number; name: string } | null
+    gameName: string
+}) {
+    const { render, shown } = useMountTransition(active, 200)
+    if (!render) return null
+    const multi = installing && progress && progress.total > 1
+    // Starts below the h-10 title bar so its drag region and window controls stay visible
+    // and usable during a drop/install; pointer-events-none keeps the app clickable too.
+    return (
+        <div
+            className={`pointer-events-none fixed inset-x-0 bottom-0 top-10 z-[9998] bg-surface/70 backdrop-blur-sm transition-opacity duration-200 ${
+                shown ? 'opacity-100' : 'opacity-0'
+            }`}
+        >
+            <div
+                className={`absolute inset-4 flex flex-col items-center justify-center gap-4 rounded-lg border-2 border-dashed border-accent bg-surface-raised/40 transition-transform duration-200 ${
+                    shown ? 'scale-100' : 'scale-[0.98]'
+                }`}
+            >
+                {installing ? (
+                    <>
+                        <Loader2 className="h-14 w-14 animate-spin text-accent" />
+                        <div className="text-xl font-semibold text-text">
+                            {multi
+                                ? t('drop.installingCount', {
+                                      current: progress.current,
+                                      total: progress.total,
+                                  })
+                                : t('drop.installing')}
+                        </div>
+                        {multi && (
+                            <div className="max-w-md truncate px-4 text-sm text-text-muted">
+                                {progress.name}
+                            </div>
+                        )}
+                    </>
+                ) : (
+                    <>
+                        <PackagePlus className="h-14 w-14 text-accent" />
+                        <div className="text-xl font-semibold text-text">
+                            {t('drop.overlayTitle')}
+                        </div>
+                        <div className="text-sm text-text-muted">
+                            {t('drop.overlaySubtitle', { game: gameName })}
+                        </div>
+                    </>
+                )}
+            </div>
+        </div>
+    )
+}
+
+export function FileDropStatus({
+    result,
+    onDismiss,
+}: {
+    result: DropResult
+    onDismiss: () => void
+}) {
+    const [shown, setShown] = useState(false)
+    useEffect(() => {
+        const id = requestAnimationFrame(() => setShown(true))
+        return () => cancelAnimationFrame(id)
+    }, [])
+    const Icon = result.kind === 'done' ? CircleCheck : CircleAlert
+    const tone =
+        result.kind === 'error'
+            ? 'border-danger/40 text-danger-text'
+            : 'border-success/40 text-success-text'
+    return (
+        <div className="fixed bottom-4 left-1/2 z-[9997] -translate-x-1/2">
+            <div
+                className={`flex items-center gap-2 rounded-lg border bg-surface-raised px-4 py-2 text-sm shadow-lg transition-all duration-200 ${tone} ${
+                    shown ? 'translate-y-0 opacity-100' : 'translate-y-2 opacity-0'
+                }`}
+            >
+                <Icon className="h-4 w-4 shrink-0" />
+                <span>{result.message}</span>
+                <button onClick={onDismiss} className="ml-1 text-text-subtle hover:text-text">
+                    <X className="h-3.5 w-3.5" />
+                </button>
+            </div>
+        </div>
+    )
+}

--- a/src/renderer/src/components/FolderSection.tsx
+++ b/src/renderer/src/components/FolderSection.tsx
@@ -52,14 +52,7 @@ export function FolderSection({ folder }: Props) {
         dragItem,
         dropTarget,
         folderActions,
-        onFolderDragStart,
-        handleDragEnd,
-        onFolderHeaderDragOver,
-        onDropIntoFolder,
-        onNestFolderInto,
-        onChildDrop,
-        onChildModDragOver,
-        onEmptyFolderDragOver,
+        onFolderPointerDown,
     } = useInstalledContext()
 
     const {
@@ -99,21 +92,10 @@ export function FolderSection({ folder }: Props) {
         >
             {isDropBeforeThis && <div className="h-0.5 rounded-full bg-accent mx-2 mb-1" />}
             <div
-                draggable={!isRenaming}
-                onDragStart={(e) => onFolderDragStart(e, folder.id)}
-                onDragEnd={handleDragEnd}
-                onDragOver={(e) => onFolderHeaderDragOver(e, folder)}
-                onDrop={() => {
-                    if (dragItem?.kind === 'mod') {
-                        onDropIntoFolder(folder.id)
-                        return
-                    }
-                    if (dragItem?.kind !== 'folder') return
-                    if (isDropInto) {
-                        onNestFolderInto(dragItem.id, folder.id)
-                        return
-                    }
-                    onChildDrop(dragItem.id, folder.id, 'folder', folder.parentId)
+                data-drop-folder-header={folder.id}
+                data-parent-id={folder.parentId ?? ''}
+                onPointerDown={(e) => {
+                    if (!isRenaming) onFolderPointerDown(e, folder.id)
                 }}
                 className={`group flex items-center gap-1.5 px-2 py-2 rounded-lg border transition-colors ${
                     !isRenaming ? 'cursor-grab active:cursor-grabbing' : ''
@@ -245,13 +227,10 @@ export function FolderSection({ folder }: Props) {
 
                     {isEmpty && creatingFolderParentId !== folder.id ? (
                         <div
+                            data-drop-empty-folder={folder.id}
                             className={`h-10 rounded-lg border border-dashed transition-colors flex items-center justify-center text-xs text-text-subtle ${
                                 isDropInto ? 'border-accent bg-accent/5' : 'border-border'
                             }`}
-                            onDragOver={(e) => onEmptyFolderDragOver(e, folder.id)}
-                            onDrop={() => {
-                                if (dragItem?.kind === 'mod') onDropIntoFolder(folder.id)
-                            }}
                         >
                             {t('installed.folder.dropHere')}
                         </div>
@@ -272,11 +251,8 @@ export function FolderSection({ folder }: Props) {
                             return (
                                 <div
                                     key={repUid}
-                                    onDragOver={(e) => onChildModDragOver(e, repUid, folder.id)}
-                                    onDrop={() =>
-                                        dragItem?.kind === 'folder' &&
-                                        onChildDrop(dragItem.id, repUid, 'mod', folder.id)
-                                    }
+                                    data-drop-child={repUid}
+                                    data-parent-id={folder.id}
                                 >
                                     {isChildDropBefore && (
                                         <div className="h-0.5 rounded-full bg-accent mx-2 mb-1" />

--- a/src/renderer/src/components/InstalledContext.tsx
+++ b/src/renderer/src/components/InstalledContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext } from 'react'
-import type { DragEvent } from 'react'
+import type { PointerEvent as ReactPointerEvent } from 'react'
 import type { GameId, InstalledMod, Mod, ModFolder } from '../../../shared/types'
 import type { FolderActions } from '../hooks/useFolderActions'
 import type { DragItem, DropTarget } from '../hooks/useDragDrop'
@@ -31,24 +31,8 @@ export interface InstalledContextValue {
     folderActions: FolderActions
     dragItem: DragItem | null
     dropTarget: DropTarget
-    onFolderDragStart: (e: DragEvent, folderId: string) => void
-    handleDragEnd: () => void
-    onFolderHeaderDragOver: (e: DragEvent, folder: ModFolder) => void
-    onDropIntoFolder: (folderId: string) => void
-    onNestFolderInto: (srcFolderId: string, targetFolderId: string) => void
-    onChildDrop: (
-        srcFolderId: string,
-        targetId: string,
-        targetItemType: 'folder' | 'mod',
-        parentId: string | null
-    ) => void
-    onChildModDragOver: (e: DragEvent, uid: string, parentId: string | null) => void
-    onEmptyFolderDragOver: (e: DragEvent, folderId: string) => void
-    handleGapDragOver: (e: DragEvent, uid: string, isBefore: boolean) => void
-    onModDropDirect: (targetRepUid: string, isBefore: boolean) => void
-    onModDragStart: (e: DragEvent, uid: string) => void
-    onModDragOver: (e: DragEvent, uid: string) => void
-    onModDrop: (targetRepUid: string) => void
+    onModPointerDown: (e: ReactPointerEvent, uid: string) => void
+    onFolderPointerDown: (e: ReactPointerEvent, folderId: string) => void
 }
 
 const InstalledContext = createContext<InstalledContextValue | null>(null)

--- a/src/renderer/src/components/InstalledModItem.tsx
+++ b/src/renderer/src/components/InstalledModItem.tsx
@@ -27,12 +27,7 @@ export function InstalledModItem({ mods }: { mods: InstalledMod[] }) {
         handleDisable,
         handleReinstall,
         requestMoveCrimeBossTarget,
-        onModDragStart,
-        onModDragOver,
-        onModDrop,
-        handleDragEnd,
-        handleGapDragOver,
-        onModDropDirect,
+        onModPointerDown,
         manageFilesKey,
         setManageFilesKey,
     } = useInstalledContext()
@@ -75,7 +70,7 @@ export function InstalledModItem({ mods }: { mods: InstalledMod[] }) {
 
     function renderMenuButton(dropdownSide: 'right' | 'left') {
         return (
-            <div ref={menuRef} className="relative" onDragStart={(e) => e.stopPropagation()}>
+            <div ref={menuRef} className="relative">
                 <button
                     onClick={(e) => {
                         e.stopPropagation()
@@ -132,33 +127,17 @@ export function InstalledModItem({ mods }: { mods: InstalledMod[] }) {
         const isBeforeActive = dropTarget?.kind === 'before-mod' && dropTarget.uid === repUid
         const isAfterActive = dropTarget?.kind === 'after-mod' && dropTarget.uid === repUid
         return (
-            <div className="relative">
-                <div
-                    className="absolute left-0 right-0 z-10 flex items-center"
-                    style={{ top: -9, height: 36 }}
-                    onDragOver={(e) => handleGapDragOver(e, repUid, true)}
-                    onDrop={(e) => {
-                        e.preventDefault()
-                        onModDropDirect(repUid, true)
-                    }}
-                >
-                    <div
-                        className={`h-0.5 w-full mx-2 rounded-full pointer-events-none ${isBeforeActive ? 'bg-accent' : 'opacity-0'}`}
-                    />
-                </div>
-                <div
-                    className="absolute left-0 right-0 z-10 flex items-center"
-                    style={{ bottom: -9, height: 36 }}
-                    onDragOver={(e) => handleGapDragOver(e, repUid, false)}
-                    onDrop={(e) => {
-                        e.preventDefault()
-                        onModDropDirect(repUid, false)
-                    }}
-                >
-                    <div
-                        className={`h-0.5 w-full mx-2 rounded-full pointer-events-none ${isAfterActive ? 'bg-accent' : 'opacity-0'}`}
-                    />
-                </div>
+            <div
+                className="relative cursor-grab active:cursor-grabbing"
+                data-drop-mod={repUid}
+                onPointerDown={(e) => onModPointerDown(e, repUid)}
+            >
+                {isBeforeActive && (
+                    <div className="absolute left-0 right-0 top-0 h-0.5 mx-2 rounded-full bg-accent z-10 pointer-events-none" />
+                )}
+                {isAfterActive && (
+                    <div className="absolute left-0 right-0 bottom-0 h-0.5 mx-2 rounded-full bg-accent z-10 pointer-events-none" />
+                )}
                 {showManageFiles && (
                     <ManageFilesModal
                         mods={mods}
@@ -178,8 +157,6 @@ export function InstalledModItem({ mods }: { mods: InstalledMod[] }) {
                     onEnable={() => handleEnable(mods)}
                     onDisable={() => handleDisable(mods)}
                     onReinstall={() => handleReinstall(mods)}
-                    onDragStart={(e) => onModDragStart(e, repUid)}
-                    onDragEnd={handleDragEnd}
                     optionsButton={renderMenuButton('left')}
                 />
             </div>
@@ -188,11 +165,8 @@ export function InstalledModItem({ mods }: { mods: InstalledMod[] }) {
 
     return (
         <div
-            draggable
-            onDragStart={(e) => onModDragStart(e, repUid)}
-            onDragOver={(e) => onModDragOver(e, repUid)}
-            onDrop={() => onModDrop(repUid)}
-            onDragEnd={handleDragEnd}
+            data-drop-mod={repUid}
+            onPointerDown={(e) => onModPointerDown(e, repUid)}
             className={`relative h-full rounded-lg cursor-grab active:cursor-grabbing transition-opacity ${isDragging ? 'opacity-40' : 'opacity-100'}`}
         >
             {dropTarget?.kind === 'before-mod' && dropTarget.uid === repUid && (
@@ -201,11 +175,7 @@ export function InstalledModItem({ mods }: { mods: InstalledMod[] }) {
             {dropTarget?.kind === 'after-mod' && dropTarget.uid === repUid && (
                 <div className="absolute top-0 bottom-0 right-0 w-1 bg-accent z-10 pointer-events-none rounded-r-lg" />
             )}
-            <div
-                ref={menuRef}
-                className="absolute top-2 right-2 z-20"
-                onDragStart={(e) => e.stopPropagation()}
-            >
+            <div ref={menuRef} className="absolute top-2 right-2 z-20">
                 <button
                     onClick={(e) => {
                         e.stopPropagation()

--- a/src/renderer/src/components/InstalledPage.tsx
+++ b/src/renderer/src/components/InstalledPage.tsx
@@ -181,25 +181,8 @@ export function InstalledPage({
 
     const folderActions = useFolderActions(gamePath, onRefreshInstalled, activeGame)
 
-    const {
-        dragItem,
-        dropTarget,
-        scrollContainerRef,
-        handleContainerDragOver,
-        handleDragEnd,
-        onModDragStart,
-        onModDragOver,
-        onFolderHeaderDragOver,
-        onChildModDragOver,
-        onEmptyFolderDragOver,
-        handleGapDragOver,
-        onModDropDirect,
-        onModDrop,
-        onDropIntoFolder,
-        onFolderDragStart,
-        onChildDrop,
-        onNestFolderInto,
-    } = useDragDrop({ installed, folders, gamePath, modData, onRefreshInstalled, activeGame })
+    const { dragItem, dropTarget, scrollContainerRef, onModPointerDown, onFolderPointerDown } =
+        useDragDrop({ installed, folders, gamePath, modData, onRefreshInstalled, activeGame })
 
     const isFiltering = filterQuery.trim().length > 0
     const { mods: displayMods, visibleFolderIds } = isFiltering
@@ -242,16 +225,8 @@ export function InstalledPage({
             return (
                 <div
                     key={repUid}
-                    onDragOver={
-                        isFolderDropZone ? (e) => onChildModDragOver(e, repUid, null) : undefined
-                    }
-                    onDrop={
-                        isFolderDropZone
-                            ? () =>
-                                  dragItem?.kind === 'folder' &&
-                                  onChildDrop(dragItem.id, repUid, 'mod', null)
-                            : undefined
-                    }
+                    data-drop-child={isFolderDropZone ? repUid : undefined}
+                    data-parent-id={isFolderDropZone ? '' : undefined}
                 >
                     {isDropBefore && <div className="h-0.5 rounded-full bg-accent mx-2 mb-1" />}
                     <InstalledModItem mods={mods} />
@@ -293,19 +268,8 @@ export function InstalledPage({
         folderActions,
         dragItem,
         dropTarget,
-        onFolderDragStart,
-        handleDragEnd,
-        onFolderHeaderDragOver,
-        onDropIntoFolder,
-        onNestFolderInto,
-        onChildDrop,
-        onChildModDragOver,
-        onEmptyFolderDragOver,
-        handleGapDragOver,
-        onModDropDirect,
-        onModDragStart,
-        onModDragOver,
-        onModDrop,
+        onModPointerDown,
+        onFolderPointerDown,
     }
 
     return (
@@ -487,7 +451,6 @@ export function InstalledPage({
                 )}
                 <div
                     ref={scrollContainerRef}
-                    onDragOver={handleContainerDragOver}
                     className="flex-1 overflow-y-auto px-6 py-4 flex flex-col gap-3"
                 >
                     {!installedReady ? (
@@ -565,13 +528,8 @@ export function InstalledPage({
                                             <div
                                                 key={`rg-${leaderId}`}
                                                 className="relative grid grid-cols-2 gap-4 xl:grid-cols-3 2xl:grid-cols-4"
-                                                onDragOver={(e) =>
-                                                    onChildModDragOver(e, leaderId, null)
-                                                }
-                                                onDrop={() =>
-                                                    dragItem?.kind === 'folder' &&
-                                                    onChildDrop(dragItem.id, leaderId, 'mod', null)
-                                                }
+                                                data-drop-child={leaderId}
+                                                data-parent-id=""
                                             >
                                                 {isGroupDropBefore && (
                                                     <div className="absolute -top-1 left-0 right-0 h-0.5 rounded-full bg-accent pointer-events-none" />

--- a/src/renderer/src/components/ModListRow.tsx
+++ b/src/renderer/src/components/ModListRow.tsx
@@ -20,10 +20,6 @@ interface Props {
     onEnable: () => void
     onDisable: () => void
     onReinstall?: () => void
-    onDragStart?: (e: React.DragEvent) => void
-    onDragOver?: (e: React.DragEvent) => void
-    onDrop?: () => void
-    onDragEnd?: () => void
     optionsButton?: ReactNode
 }
 
@@ -39,10 +35,6 @@ export function ModListRow({
     onEnable,
     onDisable,
     onReinstall,
-    onDragStart,
-    onDragOver,
-    onDrop,
-    onDragEnd,
     optionsButton,
 }: Props) {
     const thumbSrc = useThumbnail(mod.thumbnail?.file)
@@ -57,14 +49,7 @@ export function ModListRow({
             : null
 
     return (
-        <div
-            draggable
-            onDragStart={onDragStart}
-            onDragOver={onDragOver}
-            onDrop={onDrop}
-            onDragEnd={onDragEnd}
-            className="group relative rounded-lg border bg-surface-raised border-border hover:border-accent/25 transition-colors overflow-hidden"
-        >
+        <div className="group relative rounded-lg border bg-surface-raised border-border hover:border-accent/25 transition-colors overflow-hidden">
             <div
                 className={`flex items-stretch transition-opacity ${isDragging || loading ? 'opacity-40' : 'opacity-100'}`}
             >

--- a/src/renderer/src/hooks/useDragDrop.ts
+++ b/src/renderer/src/hooks/useDragDrop.ts
@@ -1,5 +1,5 @@
-import { useState, useRef } from 'react'
-import type { DragEvent } from 'react'
+import { useRef, useState, useEffect } from 'react'
+import type { PointerEvent as ReactPointerEvent } from 'react'
 import type { GameId, Mod, InstalledMod, ModFolder, TopLevelItem } from '../../../shared/types'
 import { THUMBNAIL_BASE_URL } from '../../../shared/types'
 import { computeChildren, syntheticMod } from './installedUtils'
@@ -24,6 +24,17 @@ interface Options {
     activeGame?: GameId
 }
 
+// Native OS file-drop (dragDropEnabled: true) disables HTML5 DnD in the webview, so
+// reordering runs on pointer events instead. Once a drag starts the pointer is not
+// captured; the moving element is hit-tested via document.elementFromPoint against the
+// data-drop-* attributes below. Drop targets carry:
+//   data-drop-mod=<uid>                         a mod (reorder / before-after)
+//   data-drop-folder-header=<id> data-parent-id folder header (into / reorder)
+//   data-drop-empty-folder=<id>                 an empty folder's drop zone
+//   data-drop-child=<uid|id> data-parent-id     a slot a dragged folder can sit among
+const DRAG_THRESHOLD = 5
+const SCROLL_ZONE = 80
+
 export function useDragDrop({
     installed,
     folders,
@@ -32,20 +43,51 @@ export function useDragDrop({
     onRefreshInstalled,
     activeGame,
 }: Options) {
-    const [dragItem, setDragItem] = useState<DragItem | null>(null)
+    const [dragItem, setDragItemState] = useState<DragItem | null>(null)
+    const [dropTarget, setDropTargetState] = useState<DropTarget>(null)
     const dragItemRef = useRef<DragItem | null>(null)
-    const [dropTarget, setDropTarget] = useState<DropTarget>(null)
+    const dropTargetRef = useRef<DropTarget>(null)
     const scrollContainerRef = useRef<HTMLDivElement>(null)
+
+    // Pending = pointer down on a handle but movement hasn't crossed the threshold yet.
+    const pendingRef = useRef<{
+        item: DragItem
+        startX: number
+        startY: number
+        pointerId: number
+    } | null>(null)
+    const startedRef = useRef(false)
+    const dragImageRef = useRef<HTMLElement | null>(null)
+    const imageOffsetRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 })
+    const listenersRef = useRef<{
+        move: (e: PointerEvent) => void
+        up: (e: PointerEvent) => void
+        cancel: () => void
+        key: (e: KeyboardEvent) => void
+        drag: (e: DragEvent) => void
+    } | null>(null)
+
+    // Auto-scroll while dragging near the scroll container's edges.
     const dragScrollFrame = useRef<number | null>(null)
     const dragScrollDir = useRef<'up' | 'down' | null>(null)
     const dragClientY = useRef<number>(0)
 
-    function createDragImage(e: DragEvent, mod: Mod) {
+    function setDragItem(v: DragItem | null) {
+        dragItemRef.current = v
+        setDragItemState(v)
+    }
+    function setDrop(v: DropTarget) {
+        dropTargetRef.current = v
+        setDropTargetState(v)
+    }
+
+    // ── Drag image (follows the pointer; replaces dataTransfer.setDragImage) ─────
+    function buildModDragImage(mod: Mod): HTMLElement {
         const el = document.createElement('div')
         el.style.cssText =
-            'position:fixed;top:-9999px;left:-9999px;display:flex;flex-direction:column;' +
+            'position:fixed;z-index:9999;pointer-events:none;display:flex;flex-direction:column;' +
             'background:var(--color-surface-raised);border:1px solid var(--color-border);border-radius:8px;' +
-            'box-shadow:0 4px 16px rgba(0,0,0,0.6);width:160px;overflow:hidden;pointer-events:none;'
+            'box-shadow:0 4px 16px rgba(0,0,0,0.6);width:160px;overflow:hidden;'
         if (mod.thumbnail) {
             const img = document.createElement('img')
             img.src = `${THUMBNAIL_BASE_URL}/${mod.thumbnail.file}`
@@ -62,11 +104,28 @@ export function useDragDrop({
         name.style.cssText =
             'font-size:12px;color:var(--color-text);padding:6px 8px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;'
         el.appendChild(name)
-        document.body.appendChild(el)
-        e.dataTransfer.setDragImage(el, 80, 45)
-        requestAnimationFrame(() => document.body.removeChild(el))
+        return el
     }
 
+    function buildFolderDragImage(name: string): HTMLElement {
+        const el = document.createElement('div')
+        el.textContent = name
+        el.style.cssText =
+            'position:fixed;z-index:9999;pointer-events:none;background:var(--color-surface-raised);' +
+            'border:1px solid var(--color-border);border-radius:8px;box-shadow:0 4px 16px rgba(0,0,0,0.6);' +
+            'padding:6px 10px;font-size:12px;font-weight:500;color:var(--color-text);max-width:220px;' +
+            'white-space:nowrap;overflow:hidden;text-overflow:ellipsis;'
+        return el
+    }
+
+    function positionDragImage(x: number, y: number) {
+        const el = dragImageRef.current
+        if (!el) return
+        el.style.left = `${x - imageOffsetRef.current.x}px`
+        el.style.top = `${y - imageOffsetRef.current.y}px`
+    }
+
+    // ── Auto-scroll ─────────────────────────────────────────────────────────────
     function stopAutoScroll() {
         if (dragScrollFrame.current !== null) {
             cancelAnimationFrame(dragScrollFrame.current)
@@ -74,68 +133,49 @@ export function useDragDrop({
         }
     }
 
-    function handleContainerDragOver(e: DragEvent) {
-        dragClientY.current = e.clientY
+    function updateAutoScroll(clientY: number) {
+        dragClientY.current = clientY
         const container = scrollContainerRef.current
         if (!container) return
         const { top, bottom } = container.getBoundingClientRect()
-        const ZONE = 80
         let dir: 'up' | 'down' | null = null
-        if (e.clientY < top + ZONE) dir = 'up'
-        else if (e.clientY > bottom - ZONE) dir = 'down'
-        if (dir !== dragScrollDir.current) {
-            dragScrollDir.current = dir
-            stopAutoScroll()
-            if (dir) {
-                const loop = () => {
-                    if (!dragScrollDir.current) return
-                    const ct = scrollContainerRef.current
-                    if (!ct) return
-                    const { top: t, bottom: b } = ct.getBoundingClientRect()
-                    const y = dragClientY.current
-                    const ratio =
-                        dragScrollDir.current === 'up'
-                            ? (t + ZONE - y) / ZONE
-                            : (y - (b - ZONE)) / ZONE
-                    const speed = Math.round(Math.min(1, ratio) * 12)
-                    ct.scrollBy(0, dragScrollDir.current === 'up' ? -speed : speed)
-                    dragScrollFrame.current = requestAnimationFrame(loop)
-                }
-                dragScrollFrame.current = requestAnimationFrame(loop)
-            }
-        }
-    }
-
-    function handleDragEnd() {
-        dragItemRef.current = null
-        setDragItem(null)
-        setDropTarget(null)
+        if (clientY < top + SCROLL_ZONE) dir = 'up'
+        else if (clientY > bottom - SCROLL_ZONE) dir = 'down'
+        if (dir === dragScrollDir.current) return
+        dragScrollDir.current = dir
         stopAutoScroll()
-        dragScrollDir.current = null
+        if (!dir) return
+        const loop = () => {
+            if (!dragScrollDir.current) return
+            const ct = scrollContainerRef.current
+            if (!ct) return
+            const { top: t, bottom: b } = ct.getBoundingClientRect()
+            const y = dragClientY.current
+            const ratio =
+                dragScrollDir.current === 'up'
+                    ? (t + SCROLL_ZONE - y) / SCROLL_ZONE
+                    : (y - (b - SCROLL_ZONE)) / SCROLL_ZONE
+            const speed = Math.round(Math.min(1, ratio) * 12)
+            ct.scrollBy(0, dragScrollDir.current === 'up' ? -speed : speed)
+            dragScrollFrame.current = requestAnimationFrame(loop)
+        }
+        dragScrollFrame.current = requestAnimationFrame(loop)
     }
 
-    function onModDragStart(e: DragEvent, uid: string) {
-        const ins = installed.find((m) => m.uid === uid)!
-        const mod = modData.get(ins.id) ?? syntheticMod(ins)
-        const item: DragItem = { kind: 'mod', uid }
-        dragItemRef.current = item
-        setDragItem(item)
-        createDragImage(e, mod)
-    }
-
-    function onModDragOver(e: DragEvent, uid: string) {
-        if (!dragItem || dragItem.kind === 'folder') return
-        if (dragItem.uid === uid) return
-
-        const srcMod = installed.find((m) => m.uid === dragItem.uid)
+    // ── Drop-target computation (pure; ported from the old dragOver handlers) ────
+    function computeModDragOver(clientY: number, rect: DOMRect, uid: string): DropTarget {
+        const item = dragItemRef.current
+        if (!item || item.kind === 'folder') return null
+        if (item.uid === uid) return null
+        const srcMod = installed.find((m) => m.uid === item.uid)
         const targetMod = installed.find((m) => m.uid === uid)
-        if (!srcMod || !targetMod) return
+        if (!srcMod || !targetMod) return null
 
         // Secondary-target mods (e.g. mod_overrides) can only reorder within their own scope.
-        if (srcMod.location && (srcMod.folderId ?? null) !== (targetMod.folderId ?? null)) return
+        if (srcMod.location && (srcMod.folderId ?? null) !== (targetMod.folderId ?? null))
+            return null
 
-        const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
-        const isTop = e.clientY - rect.top < rect.height / 2
+        const isTop = clientY - rect.top < rect.height / 2
 
         if ((srcMod.folderId ?? null) === (targetMod.folderId ?? null)) {
             const srcFolderId = srcMod.folderId ?? null
@@ -149,82 +189,114 @@ export function useDragDrop({
                 : srcOrigIdx > 0
                   ? scopedMods[srcOrigIdx - 1]
                   : undefined
-            if (noOpNeighbor?.id === targetMod.id) return
+            if (noOpNeighbor?.id === targetMod.id) return null
         }
 
-        e.preventDefault()
-        setDropTarget(isTop ? { kind: 'before-mod', uid } : { kind: 'after-mod', uid })
+        return isTop ? { kind: 'before-mod', uid } : { kind: 'after-mod', uid }
     }
 
-    function onFolderHeaderDragOver(e: DragEvent, folder: ModFolder) {
-        if (!dragItem) return
-        e.preventDefault()
-        if (dragItem.kind === 'mod') {
-            const srcMod = installed.find((m) => m.uid === dragItem.uid)
-            if (srcMod?.location) return
-            setDropTarget({ kind: 'into-folder', folderId: folder.id })
-        } else {
-            // folder dragged over folder header: bottom half = nest inside, top half = reorder before
-            const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
-            const isBottom = e.clientY - rect.top > rect.height / 2
-            if (isBottom && folder.id !== dragItem.id) {
-                setDropTarget({ kind: 'into-folder', folderId: folder.id })
-            } else {
-                setDropTarget({
-                    kind: 'before-child',
-                    id: folder.id,
-                    itemType: 'folder',
-                    parentId: folder.parentId,
-                })
-            }
-        }
-    }
-
-    function onChildModDragOver(e: DragEvent, uid: string, parentId: string | null) {
-        if (!dragItem || dragItem.kind !== 'folder') return
-        e.preventDefault()
-        const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
-        const isBottom = e.clientY - rect.top > rect.height / 2
-        setDropTarget(
-            isBottom
-                ? { kind: 'after-child', id: uid, itemType: 'mod', parentId }
-                : { kind: 'before-child', id: uid, itemType: 'mod', parentId }
-        )
-    }
-
-    function handleGapDragOver(e: DragEvent, uid: string, isBefore: boolean) {
+    function computeFolderHeaderDragOver(
+        clientY: number,
+        rect: DOMRect,
+        folderId: string,
+        folderParentId: string | null
+    ): DropTarget {
         const item = dragItemRef.current
-        if (!item || item.kind !== 'mod') return
-        if (item.uid === uid) return
+        if (!item) return null
+        if (item.kind === 'mod') {
+            const srcMod = installed.find((m) => m.uid === item.uid)
+            if (srcMod?.location) return null
+            return { kind: 'into-folder', folderId }
+        }
+        // folder dragged over folder header: bottom half = nest inside, top half = reorder before
+        const isBottom = clientY - rect.top > rect.height / 2
+        if (isBottom && folderId !== item.id) return { kind: 'into-folder', folderId }
+        return { kind: 'before-child', id: folderId, itemType: 'folder', parentId: folderParentId }
+    }
+
+    function computeChildModDragOver(
+        clientY: number,
+        rect: DOMRect,
+        uid: string,
+        parentId: string | null
+    ): DropTarget {
+        const item = dragItemRef.current
+        if (!item || item.kind !== 'folder') return null
+        const isBottom = clientY - rect.top > rect.height / 2
+        return isBottom
+            ? { kind: 'after-child', id: uid, itemType: 'mod', parentId }
+            : { kind: 'before-child', id: uid, itemType: 'mod', parentId }
+    }
+
+    function computeEmptyFolderDragOver(folderId: string): DropTarget {
+        const item = dragItemRef.current
+        if (!item || item.kind !== 'mod') return null
         const srcMod = installed.find((m) => m.uid === item.uid)
-        const targetMod = installed.find((m) => m.uid === uid)
+        if (srcMod?.location) return null
+        return { kind: 'into-folder', folderId }
+    }
+
+    function updateDropTarget(clientX: number, clientY: number) {
+        const item = dragItemRef.current
+        if (!item) return
+        const el = document.elementFromPoint(clientX, clientY)
+        if (!el) {
+            setDrop(null)
+            return
+        }
+        const header = el.closest('[data-drop-folder-header]') as HTMLElement | null
+        if (header) {
+            setDrop(
+                computeFolderHeaderDragOver(
+                    clientY,
+                    header.getBoundingClientRect(),
+                    header.dataset.dropFolderHeader!,
+                    header.dataset.parentId || null
+                )
+            )
+            return
+        }
+        if (item.kind === 'mod') {
+            const empty = el.closest('[data-drop-empty-folder]') as HTMLElement | null
+            if (empty) {
+                setDrop(computeEmptyFolderDragOver(empty.dataset.dropEmptyFolder!))
+                return
+            }
+            const modZone = el.closest('[data-drop-mod]') as HTMLElement | null
+            if (modZone) {
+                setDrop(
+                    computeModDragOver(
+                        clientY,
+                        modZone.getBoundingClientRect(),
+                        modZone.dataset.dropMod!
+                    )
+                )
+                return
+            }
+            setDrop(null)
+            return
+        }
+        const child = el.closest('[data-drop-child]') as HTMLElement | null
+        if (child) {
+            setDrop(
+                computeChildModDragOver(
+                    clientY,
+                    child.getBoundingClientRect(),
+                    child.dataset.dropChild!,
+                    child.dataset.parentId || null
+                )
+            )
+            return
+        }
+        setDrop(null)
+    }
+
+    // ── Drop application (ported from the old drop handlers) ─────────────────────
+    async function applyModReorder(srcRepUid: string, targetRepUid: string, isBefore: boolean) {
+        if (!gamePath || targetRepUid === srcRepUid) return
+        const srcMod = installed.find((m) => m.uid === srcRepUid)
+        const targetMod = installed.find((m) => m.uid === targetRepUid)
         if (!srcMod || !targetMod) return
-        if ((srcMod.folderId ?? null) === (targetMod.folderId ?? null)) {
-            const scopedMods = installed
-                .filter((m) => (m.folderId ?? null) === (srcMod.folderId ?? null))
-                .sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0))
-            const srcGroupSize = scopedMods.filter((m) => m.id === srcMod.id).length
-            const srcOrigIdx = scopedMods.findIndex((m) => m.uid === srcMod.uid)
-            if (isBefore) {
-                if (scopedMods[srcOrigIdx + srcGroupSize]?.id === targetMod.id) return
-            } else {
-                if (srcOrigIdx > 0 && scopedMods[srcOrigIdx - 1]?.id === targetMod.id) return
-            }
-        }
-        e.preventDefault()
-        setDropTarget(isBefore ? { kind: 'before-mod', uid } : { kind: 'after-mod', uid })
-    }
-
-    async function onModDropDirect(targetRepUid: string, isBefore: boolean) {
-        if (!dragItem || dragItem.kind !== 'mod' || !gamePath) return
-        const srcRepUid = dragItem.uid
-        dragItemRef.current = null
-        setDragItem(null)
-        setDropTarget(null)
-        if (targetRepUid === srcRepUid) return
-
-        const srcMod = installed.find((m) => m.uid === srcRepUid)!
-        const targetMod = installed.find((m) => m.uid === targetRepUid)!
         const srcFolderId = srcMod.folderId ?? null
         const targetFolderId = targetMod.folderId ?? null
         const srcGroupMods = installed
@@ -269,70 +341,10 @@ export function useDragDrop({
         await onRefreshInstalled()
     }
 
-    async function onModDrop(targetRepUid: string) {
-        if (!dragItem || dragItem.kind !== 'mod' || !gamePath) return
-        const srcRepUid = dragItem.uid
-        dragItemRef.current = null
-        setDragItem(null)
-        setDropTarget(null)
-        if (targetRepUid === srcRepUid) return
-
-        const srcMod = installed.find((m) => m.uid === srcRepUid)!
-        const targetMod = installed.find((m) => m.uid === targetRepUid)!
-        const srcFolderId = srcMod.folderId ?? null
-        const targetFolderId = targetMod.folderId ?? null
-        const isBefore = dropTarget?.kind === 'before-mod'
-        const srcGroupMods = installed
-            .filter((m) => (m.folderId ?? null) === srcFolderId && m.id === srcMod.id)
-            .sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0))
-
-        if (srcFolderId === targetFolderId) {
-            const scopedMods = installed
-                .filter((m) => (m.folderId ?? null) === srcFolderId)
-                .sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0))
-            const withoutSrc = scopedMods.filter((m) => m.id !== srcMod.id)
-            const targetGroupMods = withoutSrc.filter((m) => m.id === targetMod.id)
-            const pivotUid = isBefore
-                ? targetGroupMods[0].uid
-                : targetGroupMods[targetGroupMods.length - 1].uid
-            const pivotIdx = withoutSrc.findIndex((m) => m.uid === pivotUid)
-            const insertAt = isBefore ? pivotIdx : pivotIdx + 1
-            const reordered = [...withoutSrc]
-            reordered.splice(insertAt, 0, ...srcGroupMods)
-            await api.reorderModsInFolder(
-                srcFolderId,
-                reordered.map((m) => m.uid),
-                gamePath,
-                activeGame
-            )
-        } else if (!srcMod.location) {
-            const targetScopeMods = installed
-                .filter((m) => (m.folderId ?? null) === targetFolderId && m.id !== srcMod.id)
-                .sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0))
-            const toIdx = targetScopeMods.findIndex((m) => m.uid === targetRepUid)
-            const targetPosition = isBefore ? toIdx : toIdx + 1
-            for (const m of srcGroupMods) {
-                await api.moveModToFolder(
-                    m.uid,
-                    targetFolderId,
-                    targetPosition,
-                    gamePath,
-                    activeGame
-                )
-            }
-        }
-        await onRefreshInstalled()
-    }
-
-    async function onDropIntoFolder(folderId: string) {
-        if (!dragItem || dragItem.kind !== 'mod' || !gamePath) return
-        const srcRepUid = dragItem.uid
-        dragItemRef.current = null
-        setDragItem(null)
-        setDropTarget(null)
-        const srcMod = installed.find((m) => m.uid === srcRepUid)!
-        if ((srcMod.folderId ?? null) === folderId) return
-        if (srcMod.location) return
+    async function applyDropIntoFolder(srcRepUid: string, folderId: string) {
+        if (!gamePath) return
+        const srcMod = installed.find((m) => m.uid === srcRepUid)
+        if (!srcMod || (srcMod.folderId ?? null) === folderId || srcMod.location) return
         const srcGroupMods = installed.filter(
             (m) => (m.folderId ?? null) === (srcMod.folderId ?? null) && m.id === srcMod.id
         )
@@ -343,31 +355,14 @@ export function useDragDrop({
         await onRefreshInstalled()
     }
 
-    function onEmptyFolderDragOver(e: DragEvent, folderId: string) {
-        if (!dragItem || dragItem.kind !== 'mod') return
-        const srcMod = installed.find((m) => m.uid === dragItem.uid)
-        if (srcMod?.location) return
-        e.preventDefault()
-        setDropTarget({ kind: 'into-folder', folderId })
-    }
-
-    function onFolderDragStart(e: DragEvent, folderId: string) {
-        e.dataTransfer.effectAllowed = 'move'
-        const item: DragItem = { kind: 'folder', id: folderId }
-        dragItemRef.current = item
-        setDragItem(item)
-    }
-
-    async function onChildDrop(
+    async function applyChildDrop(
         srcFolderId: string,
         targetId: string,
         targetItemType: 'folder' | 'mod',
-        parentId: string | null
+        parentId: string | null,
+        isAfter: boolean
     ) {
         if (!gamePath) return
-        dragItemRef.current = null
-        setDragItem(null)
-        setDropTarget(null)
         if (targetItemType === 'folder' && targetId === srcFolderId) return
 
         const contextItems = computeChildren(installed, folders, parentId)
@@ -383,7 +378,7 @@ export function useDragDrop({
             (item) => item.type === targetItemType && item.id === targetId
         )
         if (insertIdx === -1) return
-        const insertPos = dropTarget?.kind === 'after-child' ? insertIdx + 1 : insertIdx
+        const insertPos = isAfter ? insertIdx + 1 : insertIdx
         items.splice(insertPos, 0, { type: 'folder', id: srcFolderId })
 
         const draggedFolder = folders.find((f) => f.id === srcFolderId)
@@ -394,32 +389,171 @@ export function useDragDrop({
         await onRefreshInstalled()
     }
 
-    async function onNestFolderInto(srcFolderId: string, targetFolderId: string) {
+    async function applyNestFolder(srcFolderId: string, targetFolderId: string) {
         if (!gamePath || srcFolderId === targetFolderId) return
-        dragItemRef.current = null
-        setDragItem(null)
-        setDropTarget(null)
         await api.moveFolder(srcFolderId, targetFolderId, gamePath, activeGame)
         await onRefreshInstalled()
     }
+
+    // ── Pointer lifecycle ───────────────────────────────────────────────────────
+    function resetDrag() {
+        startedRef.current = false
+        pendingRef.current = null
+        setDragItem(null)
+        setDrop(null)
+        if (dragImageRef.current) {
+            dragImageRef.current.remove()
+            dragImageRef.current = null
+        }
+        document.body.style.userSelect = ''
+        document.body.style.cursor = ''
+        stopAutoScroll()
+        dragScrollDir.current = null
+    }
+
+    function teardownListeners() {
+        const l = listenersRef.current
+        if (!l) return
+        window.removeEventListener('pointermove', l.move)
+        window.removeEventListener('pointerup', l.up)
+        window.removeEventListener('pointercancel', l.cancel)
+        window.removeEventListener('keydown', l.key)
+        window.removeEventListener('dragstart', l.drag)
+        listenersRef.current = null
+    }
+
+    function beginDrag(clientX: number, clientY: number) {
+        const p = pendingRef.current
+        if (!p) return
+        const item = p.item
+        startedRef.current = true
+        setDragItem(item)
+        if (item.kind === 'mod') {
+            const ins = installed.find((m) => m.uid === item.uid)
+            const mod = ins ? (modData.get(ins.id) ?? syntheticMod(ins)) : null
+            if (mod) {
+                dragImageRef.current = buildModDragImage(mod)
+                imageOffsetRef.current = { x: 80, y: 45 }
+                document.body.appendChild(dragImageRef.current)
+            }
+        } else {
+            const folder = folders.find((f) => f.id === item.id)
+            dragImageRef.current = buildFolderDragImage(folder?.displayName ?? '')
+            imageOffsetRef.current = { x: 12, y: 12 }
+            document.body.appendChild(dragImageRef.current)
+        }
+        document.body.style.userSelect = 'none'
+        document.body.style.cursor = 'grabbing'
+        positionDragImage(clientX, clientY)
+    }
+
+    function handlePointerMove(e: PointerEvent) {
+        const p = pendingRef.current
+        if (!p || e.pointerId !== p.pointerId) return
+        if (!startedRef.current) {
+            if (Math.hypot(e.clientX - p.startX, e.clientY - p.startY) < DRAG_THRESHOLD) return
+            beginDrag(e.clientX, e.clientY)
+        }
+        positionDragImage(e.clientX, e.clientY)
+        updateAutoScroll(e.clientY)
+        updateDropTarget(e.clientX, e.clientY)
+    }
+
+    async function runDrop() {
+        const item = dragItemRef.current
+        const dt = dropTargetRef.current
+        const srcUid = item?.kind === 'mod' ? item.uid : null
+        const srcFolderId = item?.kind === 'folder' ? item.id : null
+        resetDrag()
+        if (!item || !dt || !gamePath) return
+        if (item.kind === 'mod' && srcUid) {
+            if (dt.kind === 'before-mod' || dt.kind === 'after-mod') {
+                await applyModReorder(srcUid, dt.uid, dt.kind === 'before-mod')
+            } else if (dt.kind === 'into-folder') {
+                await applyDropIntoFolder(srcUid, dt.folderId)
+            }
+        } else if (item.kind === 'folder' && srcFolderId) {
+            if (dt.kind === 'into-folder') {
+                await applyNestFolder(srcFolderId, dt.folderId)
+            } else if (dt.kind === 'before-child' || dt.kind === 'after-child') {
+                await applyChildDrop(
+                    srcFolderId,
+                    dt.id,
+                    dt.itemType,
+                    dt.parentId,
+                    dt.kind === 'after-child'
+                )
+            }
+        }
+    }
+
+    function handlePointerUp() {
+        const wasDragging = startedRef.current
+        teardownListeners()
+        if (!wasDragging) {
+            resetDrag()
+            return
+        }
+        // A real drag just ended — swallow the click the browser fires next (only when
+        // pointer up/down share an element, e.g. a drop back onto the origin) so it
+        // doesn't open the mod detail page. Remove on the next tick so that, when no
+        // click fires, the guard doesn't eat the user's following real click.
+        const swallowClick = (ev: MouseEvent) => {
+            ev.stopPropagation()
+            ev.preventDefault()
+        }
+        window.addEventListener('click', swallowClick, { capture: true })
+        setTimeout(() => window.removeEventListener('click', swallowClick, true), 0)
+        void runDrop()
+    }
+
+    function cancelDrag() {
+        teardownListeners()
+        resetDrag()
+    }
+
+    function startPending(e: ReactPointerEvent, item: DragItem) {
+        if (e.button !== 0 || !gamePath) return
+        if ((e.target as HTMLElement).closest('button, a, input, textarea, select, [data-no-drag]'))
+            return
+        pendingRef.current = { item, startX: e.clientX, startY: e.clientY, pointerId: e.pointerId }
+        const move = handlePointerMove
+        const up = handlePointerUp
+        const cancel = cancelDrag
+        const key = (ev: KeyboardEvent) => {
+            if (ev.key === 'Escape') cancelDrag()
+        }
+        // Images/links are natively draggable; with dragDropEnabled: false the webview's
+        // HTML5 drag would otherwise fire and preempt our pointermove. Cancel it.
+        const drag = (ev: DragEvent) => ev.preventDefault()
+        listenersRef.current = { move, up, cancel, key, drag }
+        window.addEventListener('pointermove', move)
+        window.addEventListener('pointerup', up)
+        window.addEventListener('pointercancel', cancel)
+        window.addEventListener('keydown', key)
+        window.addEventListener('dragstart', drag)
+    }
+
+    function onModPointerDown(e: ReactPointerEvent, uid: string) {
+        startPending(e, { kind: 'mod', uid })
+    }
+    function onFolderPointerDown(e: ReactPointerEvent, folderId: string) {
+        startPending(e, { kind: 'folder', id: folderId })
+    }
+
+    useEffect(() => {
+        return () => {
+            teardownListeners()
+            resetDrag()
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
 
     return {
         dragItem,
         dropTarget,
         scrollContainerRef,
-        handleContainerDragOver,
-        handleDragEnd,
-        onModDragStart,
-        onModDragOver,
-        onFolderHeaderDragOver,
-        onChildModDragOver,
-        onEmptyFolderDragOver,
-        handleGapDragOver,
-        onModDropDirect,
-        onModDrop,
-        onDropIntoFolder,
-        onFolderDragStart,
-        onChildDrop,
-        onNestFolderInto,
+        onModPointerDown,
+        onFolderPointerDown,
     }
 }

--- a/src/renderer/src/hooks/useFileDropInstall.ts
+++ b/src/renderer/src/hooks/useFileDropInstall.ts
@@ -1,0 +1,112 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import type { GameId } from '../../../shared/types'
+import { api } from '../api'
+import { t } from '../i18n'
+
+export type DropResult = { kind: 'done' | 'error'; message: string }
+
+interface Options {
+    gamePath: string | null
+    activeGame: GameId
+    enabled: boolean
+    onRefreshInstalled: () => Promise<void>
+}
+
+function baseName(path: string): string {
+    return path.split(/[\\/]/).pop() || path
+}
+
+// Native OS file drops from Explorer install as unidentified local mods (see
+// install_dropped_file). Multi-pak / specially-packaged archives return DROP_NEEDS_PICKER
+// until Part 2b wires the archive picker.
+export function useFileDropInstall({ gamePath, activeGame, enabled, onRefreshInstalled }: Options) {
+    const [dragging, setDragging] = useState(false)
+    const [installing, setInstalling] = useState(false)
+    const [progress, setProgress] = useState<{
+        current: number
+        total: number
+        name: string
+    } | null>(null)
+    const [result, setResult] = useState<DropResult | null>(null)
+    // Latest values for the event callback, so it never re-subscribes mid-drag.
+    const optsRef = useRef<Options>({ gamePath, activeGame, enabled, onRefreshInstalled })
+    useLayoutEffect(() => {
+        optsRef.current = { gamePath, activeGame, enabled, onRefreshInstalled }
+    })
+    const installingRef = useRef(false)
+    const resultTimer = useRef<number | null>(null)
+
+    function showResult(r: DropResult) {
+        if (resultTimer.current) window.clearTimeout(resultTimer.current)
+        setResult(r)
+        resultTimer.current = window.setTimeout(() => setResult(null), 6000)
+    }
+
+    async function runInstall(paths: string[], opts: Options) {
+        if (!opts.gamePath) return
+        installingRef.current = true
+        setInstalling(true)
+        setResult(null)
+        let ok = 0
+        let needsPicker = false
+        const failed: string[] = []
+        for (let i = 0; i < paths.length; i++) {
+            const path = paths[i]
+            setProgress({ current: i + 1, total: paths.length, name: baseName(path) })
+            try {
+                await api.installDroppedFile(path, opts.gamePath, undefined, opts.activeGame)
+                ok++
+            } catch (e) {
+                if (String(e).includes('DROP_NEEDS_PICKER')) needsPicker = true
+                else failed.push(baseName(path))
+            }
+        }
+        await opts.onRefreshInstalled()
+        installingRef.current = false
+        setInstalling(false)
+        setProgress(null)
+
+        if (failed.length > 0) {
+            showResult({ kind: 'error', message: t('drop.failed', { names: failed.join(', ') }) })
+        } else if (ok === 0 && needsPicker) {
+            showResult({ kind: 'error', message: t('drop.needsPicker') })
+        } else {
+            const base = ok === 1 ? t('drop.installedSingle') : t('drop.installed', { count: ok })
+            showResult({
+                kind: 'done',
+                message: needsPicker ? `${base} · ${t('drop.needsPicker')}` : base,
+            })
+        }
+    }
+
+    useEffect(() => {
+        return api.onFileDrop((info) => {
+            const opts = optsRef.current
+            if (!opts.enabled) {
+                setDragging(false)
+                return
+            }
+            if (info.type === 'enter' || info.type === 'over') {
+                if (!installingRef.current) setDragging(true)
+                return
+            }
+            setDragging(false)
+            if (info.type === 'leave' || info.paths.length === 0 || installingRef.current) return
+            if (!opts.gamePath) {
+                showResult({ kind: 'error', message: t('drop.noGame') })
+                return
+            }
+            void runInstall(info.paths, opts)
+        })
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+
+    useEffect(
+        () => () => {
+            if (resultTimer.current) window.clearTimeout(resultTimer.current)
+        },
+        []
+    )
+
+    return { dragging, installing, progress, result, dismissResult: () => setResult(null) }
+}

--- a/src/renderer/src/hooks/useFileDropInstall.ts
+++ b/src/renderer/src/hooks/useFileDropInstall.ts
@@ -2,8 +2,17 @@ import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import type { GameId } from '../../../shared/types'
 import { api } from '../api'
 import { t } from '../i18n'
+import { handleInstallSentinel } from '../installSentinels'
+import type { ZipMultiPakPayload } from '../components/ZipPickerModal'
+import type { HostPackPayload } from '../components/HostPackModal'
+import type { CbFlatArchivePayload } from '../components/CrimeBossFlatArchiveModal'
 
 export type DropResult = { kind: 'done' | 'error'; message: string }
+
+export type DropSentinel =
+    | { kind: 'zip'; payload: ZipMultiPakPayload }
+    | { kind: 'host'; payload: HostPackPayload }
+    | { kind: 'cb'; payload: CbFlatArchivePayload }
 
 interface Options {
     gamePath: string | null
@@ -28,12 +37,19 @@ export function useFileDropInstall({ gamePath, activeGame, enabled, onRefreshIns
         name: string
     } | null>(null)
     const [result, setResult] = useState<DropResult | null>(null)
+    // Archives that need a UI decision (multi-pak / host pack / CB flat), shown one modal at a time.
+    const [sentinels, setSentinels] = useState<DropSentinel[]>([])
     // Latest values for the event callback, so it never re-subscribes mid-drag.
     const optsRef = useRef<Options>({ gamePath, activeGame, enabled, onRefreshInstalled })
     useLayoutEffect(() => {
         optsRef.current = { gamePath, activeGame, enabled, onRefreshInstalled }
     })
     const installingRef = useRef(false)
+    // Blocks a fresh drop while a picker modal from a previous drop is still open.
+    const busyRef = useRef(false)
+    useLayoutEffect(() => {
+        busyRef.current = installing || sentinels.length > 0
+    })
     const resultTimer = useRef<number | null>(null)
 
     function showResult(r: DropResult) {
@@ -48,8 +64,9 @@ export function useFileDropInstall({ gamePath, activeGame, enabled, onRefreshIns
         setInstalling(true)
         setResult(null)
         let ok = 0
-        let needsPicker = false
+        let unrecognized = false
         const failed: string[] = []
+        const collected: DropSentinel[] = []
         for (let i = 0; i < paths.length; i++) {
             const path = paths[i]
             setProgress({ current: i + 1, total: paths.length, name: baseName(path) })
@@ -57,8 +74,15 @@ export function useFileDropInstall({ gamePath, activeGame, enabled, onRefreshIns
                 await api.installDroppedFile(path, opts.gamePath, undefined, opts.activeGame)
                 ok++
             } catch (e) {
-                if (String(e).includes('DROP_NEEDS_PICKER')) needsPicker = true
-                else failed.push(baseName(path))
+                const handled = handleInstallSentinel(String(e), {
+                    onZipMultiPak: (payload) => collected.push({ kind: 'zip', payload }),
+                    onHostModPack: (payload) => collected.push({ kind: 'host', payload }),
+                    onCbFlatArchive: (payload) => collected.push({ kind: 'cb', payload }),
+                    onUnrecognizedArchive: () => {
+                        unrecognized = true
+                    },
+                })
+                if (!handled) failed.push(baseName(path))
             }
         }
         await opts.onRefreshInstalled()
@@ -66,17 +90,20 @@ export function useFileDropInstall({ gamePath, activeGame, enabled, onRefreshIns
         setInstalling(false)
         setProgress(null)
 
+        // Sentinels get their own modals; only the directly-resolved outcomes drive the toast.
         if (failed.length > 0) {
             showResult({ kind: 'error', message: t('drop.failed', { names: failed.join(', ') }) })
-        } else if (ok === 0 && needsPicker) {
-            showResult({ kind: 'error', message: t('drop.needsPicker') })
-        } else {
+        } else if (ok > 0) {
             const base = ok === 1 ? t('drop.installedSingle') : t('drop.installed', { count: ok })
             showResult({
                 kind: 'done',
-                message: needsPicker ? `${base} · ${t('drop.needsPicker')}` : base,
+                message: unrecognized ? `${base} · ${t('drop.needsPicker')}` : base,
             })
+        } else if (unrecognized && collected.length === 0) {
+            showResult({ kind: 'error', message: t('drop.needsPicker') })
         }
+
+        if (collected.length > 0) setSentinels(collected)
     }
 
     useEffect(() => {
@@ -87,11 +114,11 @@ export function useFileDropInstall({ gamePath, activeGame, enabled, onRefreshIns
                 return
             }
             if (info.type === 'enter' || info.type === 'over') {
-                if (!installingRef.current) setDragging(true)
+                if (!busyRef.current) setDragging(true)
                 return
             }
             setDragging(false)
-            if (info.type === 'leave' || info.paths.length === 0 || installingRef.current) return
+            if (info.type === 'leave' || info.paths.length === 0 || busyRef.current) return
             if (!opts.gamePath) {
                 showResult({ kind: 'error', message: t('drop.noGame') })
                 return
@@ -108,5 +135,13 @@ export function useFileDropInstall({ gamePath, activeGame, enabled, onRefreshIns
         []
     )
 
-    return { dragging, installing, progress, result, dismissResult: () => setResult(null) }
+    return {
+        dragging,
+        installing,
+        progress,
+        result,
+        dismissResult: () => setResult(null),
+        sentinel: sentinels[0] ?? null,
+        resolveSentinel: () => setSentinels((s) => s.slice(1)),
+    }
 }

--- a/src/renderer/src/i18n/en.json
+++ b/src/renderer/src/i18n/en.json
@@ -449,5 +449,16 @@
         "settingsDescription": "Share anonymous usage data to help improve Modrex.",
         "discordPresenceTitle": "Discord Rich Presence",
         "discordPresenceDescription": "Show Modrex activity on your Discord profile with a link to the app."
+    },
+    "drop": {
+        "overlayTitle": "Drop to install",
+        "overlaySubtitle": "Release to install into {game}",
+        "installing": "Installing…",
+        "installingCount": "Installing {current} of {total}…",
+        "installed": "Installed {count} mods",
+        "installedSingle": "Installed 1 mod",
+        "needsPicker": "Some archives must be installed from their mod page for now",
+        "failed": "Could not install: {names}",
+        "noGame": "Set your game folder before dropping mods"
     }
 }


### PR DESCRIPTION
## What does this PR do?

Closes #5.

Adds installing mods by dragging files from the OS file explorer onto the window, so a local `.pak` or mod archive can be installed without going through a mod page.

- Reorder/folder drag-and-drop on the Installed page moves from HTML5 drag events to pointer events, so native file drop can be enabled without breaking it.
- Native file drop is enabled; `install_dropped_file` copies the dropped file to a temp location, resolves it, and installs it. Unidentified files are matched by SHA256 against the index on the next refresh.
- A full-screen drop overlay shows per-file install progress, and the title bar stays usable during installs.
- Multi-pak, Crime Boss loose-triplet, and PD2 host-pack archives route through the existing install pickers; unrecognized archives show a plain message.

## Checklist

- [x] `pnpm format` passes
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes
- [x] `pnpm generate-licenses` run (if dependencies changed)