### PR TITLE
feat(desktop): identify Nexus mods by content and archive hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Modrex are documented in this file. Each version's sectio
 ### Added
 
 - Added Nexus Mods as a second mod source for PAYDAY 3, PAYDAY 2, PAYDAY: The Heist, and Crime Boss: Rockay City. Browse and install through OAuth sign-in and website mod-manager downloads, choosing between ModWorkshop and Nexus Mods from the top of the Browse page.
+- Unrecognized Nexus mods can now be identified by matching them against Nexus's own listings: dragged-in archives at drop time, and already-installed mods automatically or on demand from a mod's options menu.
 - New About tab in Settings with project info and quick links to the GitHub repository, GitHub Sponsors, Discord, and modrex.net.
 - A one-time banner asking for a GitHub star, shown once ever after the 10th successful mod install (and at least a week of use). Dismissing it is permanent.
 - Added support for RAID: World War II: browse, install, and manage its mods (SuperBLT and legacy RaidBLT script mods plus asset override packs, all installed into the game's `mods` folder as the current loader expects), with one-click install and dependency detection for the RAID-SuperBLT mod loader.
@@ -55,6 +56,7 @@ All notable changes to Modrex are documented in this file. Each version's sectio
 - Fixed the Launch and Launch Modded buttons showing in Settings when it was opened without a game selected.
 - Fixed several dialogs missing a close button in the top corner, so every dialog can now be closed with an X.
 - Fixed the Linux app not having a proper icon in the taskbar, application menu, and window switcher.
+- Fixed dragged-in downloaded archives being named after the download's filename instead of the mod's real name.
 
 ### Security
 

--- a/apps/desktop/THIRD_PARTY_LICENSES.md
+++ b/apps/desktop/THIRD_PARTY_LICENSES.md
@@ -8738,7 +8738,7 @@ THE SOFTWARE.
 
 ## MIT License
 
-Used by: sha2 0.11.0
+Used by: md-5 0.11.0, sha2 0.11.0
 
 ```
 Copyright (c) 2016-2026 The RustCrypto Project Developers

--- a/apps/desktop/scripts/check-sources.mjs
+++ b/apps/desktop/scripts/check-sources.mjs
@@ -1,13 +1,15 @@
 import { readFileSync } from 'fs'
 
-// modworkshop's per-game id is registered twice by necessity: SOURCE_REGISTRY in Rust and
-// workshopId in @modrex/games, which the renderer uses directly to build API calls. Neither
+// Both modworkshop's per-game id and Nexus's per-game domain are registered twice by
+// necessity: SOURCE_REGISTRY in Rust, and workshopId/nexusDomain in @modrex/games. Neither
 // side can see the other, so adding a game to one and forgetting the other compiles fine
-// and fails at runtime. This check diffs the two.
+// and fails at runtime. This check diffs both.
 //
-// Nexus is deliberately NOT checked here: the renderer reads its per-game domain from the
-// registry over IPC (sources.ts), so there is no second list to drift. Any source added
-// that way needs no entry here.
+// The desktop renderer itself reads Nexus's domain from the registry over IPC
+// (sources.ts) and never touches @modrex/games' nexusDomain - but apps/site has no IPC
+// (it is a static build, not a Tauri app) and reads nexusDomain directly to query Nexus's
+// mod counts at build time, so that copy is real, and diffed here the same way workshopId
+// already is.
 
 const rust = readFileSync('src-tauri/src/commands/sources.rs', 'utf8')
 const registryBlock = rust.match(/SOURCE_REGISTRY: &\[SourceSpec\] = &\[([\s\S]*?)\n\];/)?.[1]
@@ -34,13 +36,16 @@ if (!specsBlock) {
     process.exit(1)
 }
 
-// One entry per game, carrying workshopId.
+// One entry per game, carrying workshopId and nexusDomain.
 const tsWorkshop = new Map()
+const tsNexus = new Map()
 for (const chunk of specsBlock.split(/^ {4}(?=\w+:\s*\{)/m)) {
     const gameId = chunk.match(/^(\w+):\s*\{/)?.[1]
     if (!gameId) continue
     const workshopId = chunk.match(/workshopId:\s*(\d+)/)?.[1]
     if (workshopId) tsWorkshop.set(gameId, workshopId)
+    const nexusDomain = chunk.match(/nexusDomain:\s*'([^']+)'/)?.[1]
+    if (nexusDomain) tsNexus.set(gameId, nexusDomain)
 }
 
 const errors = []
@@ -72,6 +77,7 @@ function diff(sourceId, tsMap) {
 }
 
 diff('modworkshop', tsWorkshop)
+diff('nexus', tsNexus)
 
 if (errors.length > 0) {
     console.error('Source registry disagrees between Rust and TypeScript:')
@@ -80,5 +86,5 @@ if (errors.length > 0) {
 }
 
 console.log(
-    `check-sources: ${tsWorkshop.size} modworkshop game mappings agree between Rust and TypeScript`
+    `check-sources: ${tsWorkshop.size} modworkshop and ${tsNexus.size} nexus game mappings agree between Rust and TypeScript`
 )

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2593,6 +2593,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2653,6 +2663,7 @@ dependencies = [
  "hex",
  "keyring",
  "log",
+ "md-5",
  "percent-encoding",
  "rand",
  "reqwest",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -33,6 +33,7 @@ futures = "0.3"
 tokio = { version = "1", features = ["fs", "process", "sync", "time"] }
 tauri-plugin-updater = "2"
 sha2 = "0.11"
+md-5 = "0.11"
 hex = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
 rusqlite = { version = "0.40", features = ["bundled"] }

--- a/apps/desktop/src-tauri/src/commands/mods/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/mod.rs
@@ -979,6 +979,28 @@ fn recover_dropped_mod_stem(
         .unwrap_or_else(|| fallback.to_string())
 }
 
+/// Overwrites the generic unidentified fields on a freshly built InstalledMod with a
+/// confirmed Nexus identity. uid switches to Tier 1's own "nexus:{mod_id}:{file_id}"
+/// scheme so a later nxm:// install of the same file reconciles onto this entry
+/// instead of creating a duplicate.
+fn apply_nexus_archive_identity(
+    entry: &mut InstalledMod,
+    m: &crate::commands::nexus::NexusHashMatch,
+    detail: &crate::commands::domain::ModDetail,
+) {
+    entry.uid = format!("nexus:{}:{}", m.mod_id, m.file_id);
+    entry.id = sources::source_native_local_id("nexus", &m.mod_id.to_string());
+    entry.name = detail.name.clone();
+    entry.version = detail.version.clone();
+    entry.update_status = UpdateStatus::Known;
+    entry.source = "nexus".to_string();
+    entry.remote_id = Some(m.mod_id.to_string());
+    entry.file_remote_id = Some(m.file_id.to_string());
+    entry.author = Some(detail.user.name.clone());
+    entry.thumbnail_url = detail.thumbnail.as_ref().map(|t| t.file.clone());
+    entry.file_id = Some(m.file_id as i64);
+}
+
 /// Installs a mod from a local file the user dropped onto the window (Explorer drag-drop).
 /// The file carries no modworkshop identity, so it is installed as an unidentified entry
 /// (negative id, "unknown" version) exactly like an ambiently-discovered pak; get_installed's
@@ -1060,6 +1082,55 @@ pub async fn install_dropped_file(
         &file_stem,
     );
 
+    // Best-effort Nexus identification: only possible when the whole downloaded
+    // archive is still available (zip_orig - a bare loose .pak drop has nothing
+    // Nexus's archive-MD5 index could ever match) and the game has a Nexus presence.
+    // A miss, an ambiguous result, or a lookup failure all fall through to the
+    // ordinary unidentified install below - this only ever adds an identity on top
+    // of it, never blocks or fails the install itself.
+    let nexus_match = match &zip_orig {
+        Some(archive) if sources::native_id("nexus", &game_id).is_some() => {
+            match crate::commands::nexus::identify_archive_by_md5(
+                app.clone(),
+                game_id.clone(),
+                archive,
+            )
+            .await
+            {
+                Ok(crate::commands::nexus::NexusArchiveIdentity::Identified(m)) => Some(m),
+                Ok(_) => None,
+                Err(e) => {
+                    log::warn!("install_dropped_file: nexus identification failed: {e}");
+                    None
+                }
+            }
+        }
+        _ => None,
+    };
+    // A hash match without its enrichment detail is not installed as identified -
+    // apply_nexus_archive_identity only runs when both are present - but the failure
+    // is still worth a log line, same as the identification lookup above.
+    let nexus_detail = match &nexus_match {
+        Some(m) => {
+            match crate::commands::nexus::nexus_get_mod(app.clone(), game_id.clone(), m.mod_id)
+                .await
+            {
+                Ok(value) => match crate::commands::domain::parse_nexus_detail(value) {
+                    Ok(detail) => Some(detail),
+                    Err(e) => {
+                        log::warn!("install_dropped_file: nexus detail parse failed: {e}");
+                        None
+                    }
+                },
+                Err(e) => {
+                    log::warn!("install_dropped_file: nexus detail fetch failed: {e}");
+                    None
+                }
+            }
+        }
+        None => None,
+    };
+
     let result = async {
         let sha256 = match &target.unit {
             engine::ModUnit::File { .. } => compute_sha256(&tmp).await?,
@@ -1086,30 +1157,25 @@ pub async fn install_dropped_file(
             }
             engine::ModUnit::Directory { .. } => display_stem.clone(),
         };
-        let uid = strip_priority_prefix(&filename).to_string();
-        let id = hash_filename(&filename);
         let sp = get_state_path(&game_path, cfg);
 
-        install_mod_from_path(
-            &game_path,
-            &sp,
-            InstalledMod {
-                uid,
-                id,
-                name: display_stem.clone(),
-                version: String::new(),
-                update_status: UpdateStatus::Unknown,
-                filename,
-                enabled: true,
-                installed_at: Utc::now().to_rfc3339(),
-                sha256: Some(sha256),
-                ..InstalledMod::default()
-            },
-            &tmp,
-            folder_id,
-            cfg,
-            target,
-        )?;
+        let mut mod_entry = InstalledMod {
+            uid: strip_priority_prefix(&filename).to_string(),
+            id: hash_filename(&filename),
+            name: display_stem.clone(),
+            version: String::new(),
+            update_status: UpdateStatus::Unknown,
+            filename,
+            enabled: true,
+            installed_at: Utc::now().to_rfc3339(),
+            sha256: Some(sha256),
+            ..InstalledMod::default()
+        };
+        if let (Some(m), Some(detail)) = (&nexus_match, &nexus_detail) {
+            apply_nexus_archive_identity(&mut mod_entry, m, detail);
+        }
+
+        install_mod_from_path(&game_path, &sp, mod_entry, &tmp, folder_id, cfg, target)?;
         Ok::<(), String>(())
     }
     .await;

--- a/apps/desktop/src-tauri/src/commands/mods/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/mod.rs
@@ -43,10 +43,7 @@ pub(crate) use self::install::{
     disable_mod_op, enable_mod_op, install_host_pack_op, move_crimeboss_mod_target_op,
     uninstall_mod_op,
 };
-pub(crate) use self::naming::{
-    derive_content_segment, hash_filename, pak_filename, recover_published_filename,
-    strip_priority_prefix,
-};
+pub(crate) use self::naming::{hash_filename, pak_filename, strip_priority_prefix};
 pub(crate) use self::paths::{active_mod_path, disabled_base, disabled_mod_path};
 pub(crate) use self::reorder::{
     move_mod_to_folder_op, reorder_children_op, reorder_mods_in_folder_op,
@@ -66,7 +63,10 @@ pub(crate) use self::crimeboss_settings::{
 #[cfg(test)]
 pub(crate) use self::engine::{disabled_dir, mods_dir};
 #[cfg(test)]
-pub(crate) use self::naming::{apply_priority_prefix, make_uid, mod_folder_name};
+pub(crate) use self::naming::{
+    apply_priority_prefix, derive_content_segment, make_uid, mod_folder_name,
+    recover_published_filename,
+};
 #[cfg(test)]
 pub(crate) use self::ue4ss_modstxt::{
     entry_name, read_enabled_from_mods_txt, set_enabled_in_mods_txt,
@@ -1588,6 +1588,45 @@ pub async fn disable_mod(
         serde_json::json!({ "game": game_id.as_str() }),
     );
     Ok(())
+}
+
+/// User-initiated Tier 3 identification (see nexus_content.rs): looks up one already-
+/// installed, unidentified mod against Nexus's content index. Never called from
+/// get_installed — the renderer calls this per-mod from an explicit "Identify" action,
+/// same shape as the ModWorkshop identification pipeline being automatic (SHA256) while
+/// this one, lacking a hash to key on, cannot safely be.
+#[tauri::command]
+#[specta::specta]
+pub async fn identify_mod_via_nexus_content(
+    app: AppHandle,
+    game_path: String,
+    uid: String,
+    game_id: String,
+) -> Result<nexus_content::NexusContentIdentifyOutcome, String> {
+    let _state_guard = lock_game_state(&app, game_id.as_str()).await;
+    let cfg = engine_for_game(game_id.as_str())?;
+    let state_path = get_state_path(&game_path, cfg);
+    let mut state = read_state(&state_path);
+
+    let Some(m) = state.mods.iter_mut().find(|m| m.uid == uid) else {
+        return Err(format!("identify_mod_via_nexus_content: no mod with uid '{uid}'"));
+    };
+    let target = cfg.target_for(m.location.as_deref());
+
+    let outcome = nexus_content::identify_via_nexus_content_op(
+        &app,
+        game_id.as_str(),
+        &game_path,
+        &state.folders,
+        target,
+        m,
+    )
+    .await?;
+
+    if outcome != nexus_content::NexusContentIdentifyOutcome::Skipped {
+        save_state(&state_path, &state);
+    }
+    Ok(outcome)
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/commands/mods/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/mod.rs
@@ -51,8 +51,8 @@ pub(crate) use self::reorder::{
 pub(crate) use self::state::save_state;
 pub(crate) use self::zip::{
     extract_archive_flat, extract_dir_entry, extract_entry, extract_entry_into_crimeboss_skeleton,
-    extract_entry_with_sidecars, mark_archive_files, resolve_archive_download, InstallPrompt,
-    ModContext, ResolveError,
+    extract_entry_with_sidecars, list_pak_entries, mark_archive_files, resolve_archive_download,
+    InstallPrompt, ModContext, ResolveError,
 };
 
 // Re-exports needed only in test builds (suppressed in release to avoid unused-import warnings)
@@ -74,7 +74,7 @@ pub(crate) use self::ue4ss_modstxt::{
 #[cfg(test)]
 pub(crate) use self::zip::{
     classify_archive_dirs, detect_archive, has_ue4ss_loader_signature, is_unplaceable_pack, is_zip,
-    list_pak_entries, safe_dest, ArchiveFormat,
+    safe_dest, ArchiveFormat,
 };
 
 use crate::commands::api::{api_get, http_client, user_agent};
@@ -941,6 +941,44 @@ pub(crate) async fn install_nexus_download(
     result
 }
 
+/// Recovers a dropped mod's real name, for both display and the on-disk filename. The
+/// dropped archive's own OS filename is often a download manager's naming scheme (Nexus's
+/// website downloads are "{Name} {id} {version} {timestamp} {hash}.zip"), not the mod's
+/// real name — `fallback` (the dropped file's own stem) is only correct when nothing
+/// better is available, which is exactly the case for a bare loose .pak dropped with no
+/// zip wrapper around it.
+///
+/// Directory-unit's `tmp` already carries the real folder name (resolve_archive_download's
+/// two-level temp makes `tmp.file_name()` the mod's own directory name), but File-unit's
+/// `tmp` is a random-uuid path and Crime Boss's is an opaque skeleton root with no readable
+/// name of its own (see extract_entry_into_crimeboss_skeleton) — both need the real name
+/// pulled back out of the original archive's single pak entry instead.
+fn recover_dropped_mod_stem(
+    unit: &engine::ModUnit,
+    is_crimeboss: bool,
+    tmp: &std::path::Path,
+    zip_orig: Option<&std::path::Path>,
+    fallback: &str,
+) -> String {
+    if matches!(unit, engine::ModUnit::Directory { .. }) && !is_crimeboss {
+        return tmp
+            .file_name()
+            .and_then(|s| s.to_str())
+            .map(String::from)
+            .unwrap_or_else(|| fallback.to_string());
+    }
+    zip_orig
+        .and_then(|orig| list_pak_entries(orig).ok())
+        .and_then(|entries| match entries.as_slice() {
+            [entry] => std::path::Path::new(entry)
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .map(String::from),
+            _ => None,
+        })
+        .unwrap_or_else(|| fallback.to_string())
+}
+
 /// Installs a mod from a local file the user dropped onto the window (Explorer drag-drop).
 /// The file carries no modworkshop identity, so it is installed as an unidentified entry
 /// (negative id, "unknown" version) exactly like an ambiently-discovered pak; get_installed's
@@ -1014,6 +1052,13 @@ pub async fn install_dropped_file(
     };
     let _state_guard = lock_game_state(&app, game_id.as_str()).await;
     let target = cfg.target_for(location_tag.as_deref());
+    let display_stem = recover_dropped_mod_stem(
+        &target.unit,
+        cfg.game_id == "cb",
+        &tmp,
+        zip_orig.as_deref(),
+        &file_stem,
+    );
 
     let result = async {
         let sha256 = match &target.unit {
@@ -1035,15 +1080,11 @@ pub async fn install_dropped_file(
         // Discovery-matching identity: filename drives the uid/id the untracked-scan would assign,
         // so a later manual refresh reconciles this entry instead of duplicating it.
         let filename = match &target.unit {
-            engine::ModUnit::File { .. } => pak_filename(&file_stem),
+            engine::ModUnit::File { .. } => pak_filename(&display_stem),
             engine::ModUnit::Directory { .. } if cfg.game_id == "cb" => {
-                naming::mod_folder_name(&file_stem)
+                naming::mod_folder_name(&display_stem)
             }
-            engine::ModUnit::Directory { .. } => tmp
-                .file_name()
-                .and_then(|s| s.to_str())
-                .unwrap_or(&file_stem)
-                .to_string(),
+            engine::ModUnit::Directory { .. } => display_stem.clone(),
         };
         let uid = strip_priority_prefix(&filename).to_string();
         let id = hash_filename(&filename);
@@ -1055,7 +1096,7 @@ pub async fn install_dropped_file(
             InstalledMod {
                 uid,
                 id,
-                name: file_stem.clone(),
+                name: display_stem.clone(),
                 version: String::new(),
                 update_status: UpdateStatus::Unknown,
                 filename,
@@ -1609,7 +1650,9 @@ pub async fn identify_mod_via_nexus_content(
     let mut state = read_state(&state_path);
 
     let Some(m) = state.mods.iter_mut().find(|m| m.uid == uid) else {
-        return Err(format!("identify_mod_via_nexus_content: no mod with uid '{uid}'"));
+        return Err(format!(
+            "identify_mod_via_nexus_content: no mod with uid '{uid}'"
+        ));
     };
     let target = cfg.target_for(m.location.as_deref());
 

--- a/apps/desktop/src-tauri/src/commands/mods/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/mod.rs
@@ -5,6 +5,7 @@ mod host_mods;
 mod identify;
 mod install;
 mod naming;
+mod nexus_content;
 mod paths;
 mod pdmod;
 mod reorder;
@@ -42,7 +43,10 @@ pub(crate) use self::install::{
     disable_mod_op, enable_mod_op, install_host_pack_op, move_crimeboss_mod_target_op,
     uninstall_mod_op,
 };
-pub(crate) use self::naming::{hash_filename, pak_filename, strip_priority_prefix};
+pub(crate) use self::naming::{
+    derive_content_segment, hash_filename, pak_filename, recover_published_filename,
+    strip_priority_prefix,
+};
 pub(crate) use self::paths::{active_mod_path, disabled_base, disabled_mod_path};
 pub(crate) use self::reorder::{
     move_mod_to_folder_op, reorder_children_op, reorder_mods_in_folder_op,

--- a/apps/desktop/src-tauri/src/commands/mods/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/mod.rs
@@ -24,7 +24,7 @@ pub use self::state::{get_folder_path, read_state, reconcile_state};
 pub use self::types::{
     InstalledMod, InstalledResponse, ModFolder, ModsState, TopLevelItem, UpdateStatus,
 };
-pub use self::zip::compute_sha256;
+pub use self::zip::{compute_md5, compute_sha256};
 
 // Mod-identification helpers (get_installed pipeline) — see identify.rs
 #[cfg(test)]

--- a/apps/desktop/src-tauri/src/commands/mods/naming.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/naming.rs
@@ -109,7 +109,9 @@ pub fn recover_published_filename(on_disk_name: &str, disabled_suffix: &str) -> 
 /// cannot be matched this way, no matter what folder Modrex synthesized to hold it.
 pub fn derive_content_segment(folder_ref: &str) -> Option<&str> {
     const OVERRIDE_PREFIX: &str = "assets/mod_overrides/";
-    let stripped = folder_ref.strip_prefix(OVERRIDE_PREFIX).unwrap_or(folder_ref);
+    let stripped = folder_ref
+        .strip_prefix(OVERRIDE_PREFIX)
+        .unwrap_or(folder_ref);
     if stripped.is_empty() {
         None
     } else {

--- a/apps/desktop/src-tauri/src/commands/mods/naming.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/naming.rs
@@ -88,3 +88,31 @@ pub fn make_uid(file_id: Option<i64>, filename: &str) -> String {
         None => strip_priority_prefix(filename).to_string(),
     }
 }
+
+/// Recovers a File-unit mod's published filename from its on-disk name, for querying
+/// Nexus's content index. Modrex rewrites the name on disk (a numeric priority prefix,
+/// and a disabled_suffix appended when the mod is off); querying either as-is returns
+/// zero matches because Nexus indexed the archive's original filename.
+pub fn recover_published_filename(on_disk_name: &str, disabled_suffix: &str) -> String {
+    let without_prefix = strip_priority_prefix(on_disk_name);
+    without_prefix
+        .strip_suffix(disabled_suffix)
+        .unwrap_or(without_prefix)
+        .to_string()
+}
+
+/// Derives the folder-name segment to query Nexus's content index with, for a
+/// Directory-unit mod. Nexus paths appear both as <Name>/main.xml and
+/// assets/mod_overrides/<Name>/main.xml, so a leading assets/mod_overrides/ is
+/// stripped when present. Returns None when nothing usable remains — an archive that
+/// ships a bare root-level marker file has no wrapper folder in Nexus's own index and
+/// cannot be matched this way, no matter what folder Modrex synthesized to hold it.
+pub fn derive_content_segment(folder_ref: &str) -> Option<&str> {
+    const OVERRIDE_PREFIX: &str = "assets/mod_overrides/";
+    let stripped = folder_ref.strip_prefix(OVERRIDE_PREFIX).unwrap_or(folder_ref);
+    if stripped.is_empty() {
+        None
+    } else {
+        Some(stripped)
+    }
+}

--- a/apps/desktop/src-tauri/src/commands/mods/nexus_content.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/nexus_content.rs
@@ -93,8 +93,7 @@ pub(crate) async fn identify_via_nexus_content_op(
         return Ok(NexusContentIdentifyOutcome::Skipped);
     };
 
-    let ids =
-        nexus::nexus_lookup_content_mod_ids(app.clone(), game_id.to_string(), query).await?;
+    let ids = nexus::nexus_lookup_content_mod_ids(app.clone(), game_id.to_string(), query).await?;
 
     match ids.as_slice() {
         [] => {
@@ -103,7 +102,8 @@ pub(crate) async fn identify_via_nexus_content_op(
         }
         [mod_id] => {
             let mod_id = *mod_id;
-            let detail_value = nexus::nexus_get_mod(app.clone(), game_id.to_string(), mod_id).await?;
+            let detail_value =
+                nexus::nexus_get_mod(app.clone(), game_id.to_string(), mod_id).await?;
             let detail = crate::commands::domain::parse_nexus_detail(detail_value)?;
             m.source = "nexus".to_string();
             m.remote_id = Some(mod_id.to_string());
@@ -174,8 +174,7 @@ mod tests {
 
     #[test]
     fn directory_unit_strips_the_mod_overrides_wrapper() {
-        let query =
-            nexus_content_query_for(&directory_unit(), "assets/mod_overrides/Welrod", None);
+        let query = nexus_content_query_for(&directory_unit(), "assets/mod_overrides/Welrod", None);
         assert_eq!(
             query,
             Some(NexusContentQuery::FolderSegment {

--- a/apps/desktop/src-tauri/src/commands/mods/nexus_content.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/nexus_content.rs
@@ -1,0 +1,103 @@
+// Selects which shape of Nexus content query a mod needs, branching on ModUnit rather
+// than on game — the two engine families need genuinely different discriminators (see
+// engine.rs's ModUnit and the Tier 3 algorithm in the Nexus identification plan), and
+// collapsing them into one "generic" matcher would silently produce the wrong query for
+// half of Modrex's games. The actual network call lives in commands::nexus; this module
+// only decides what to ask.
+
+use super::engine::ModUnit;
+use super::naming::{derive_content_segment, recover_published_filename};
+use crate::commands::nexus::NexusContentQuery;
+
+/// Builds the Nexus content query for an installed mod, or None when nothing usable
+/// can be derived (a Directory-unit mod with no folder segment, or a File-unit mod
+/// whose on-disk byte size is not yet known).
+pub(crate) fn nexus_content_query_for(
+    unit: &ModUnit,
+    on_disk_filename: &str,
+    file_size: Option<i64>,
+) -> Option<NexusContentQuery> {
+    match unit {
+        ModUnit::File {
+            disabled_suffix, ..
+        } => {
+            let file_name = recover_published_filename(on_disk_filename, disabled_suffix);
+            Some(NexusContentQuery::FileNameAndSize {
+                file_name,
+                file_size: file_size?,
+            })
+        }
+        ModUnit::Directory { .. } => {
+            let segment = derive_content_segment(on_disk_filename)?.to_string();
+            Some(NexusContentQuery::FolderSegment { segment })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn file_unit() -> ModUnit {
+        ModUnit::File {
+            extension: "pak",
+            disabled_suffix: ".disabled",
+            priority_prefix: true,
+        }
+    }
+
+    fn directory_unit() -> ModUnit {
+        ModUnit::Directory {
+            entry_markers: &["mod.txt", "main.xml"],
+            scan_markers: &["mod.txt", "main.xml"],
+            index_gated_markers: &[],
+            excluded_names: &[],
+            priority_prefix: false,
+        }
+    }
+
+    #[test]
+    fn file_unit_recovers_the_published_name_and_carries_size() {
+        let query = nexus_content_query_for(&file_unit(), "003_Foo.pak.disabled", Some(468));
+        assert_eq!(
+            query,
+            Some(NexusContentQuery::FileNameAndSize {
+                file_name: "Foo.pak".to_string(),
+                file_size: 468,
+            })
+        );
+    }
+
+    #[test]
+    fn file_unit_with_no_known_size_is_not_queryable() {
+        assert_eq!(nexus_content_query_for(&file_unit(), "Foo.pak", None), None);
+    }
+
+    #[test]
+    fn directory_unit_uses_the_folder_name_as_a_segment() {
+        let query = nexus_content_query_for(&directory_unit(), "Welrod", None);
+        assert_eq!(
+            query,
+            Some(NexusContentQuery::FolderSegment {
+                segment: "Welrod".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn directory_unit_strips_the_mod_overrides_wrapper() {
+        let query =
+            nexus_content_query_for(&directory_unit(), "assets/mod_overrides/Welrod", None);
+        assert_eq!(
+            query,
+            Some(NexusContentQuery::FolderSegment {
+                segment: "Welrod".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn directory_unit_with_no_usable_segment_is_not_queryable() {
+        assert_eq!(nexus_content_query_for(&directory_unit(), "", None), None);
+    }
+}

--- a/apps/desktop/src-tauri/src/commands/mods/nexus_content.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/nexus_content.rs
@@ -5,9 +5,13 @@
 // half of Modrex's games. The actual network call lives in commands::nexus; this module
 // only decides what to ask.
 
-use super::engine::ModUnit;
+use super::engine::{ModUnit, ScanTarget};
 use super::naming::{derive_content_segment, recover_published_filename};
-use crate::commands::nexus::NexusContentQuery;
+use super::paths::{active_mod_path, disabled_mod_path};
+use super::state::get_folder_path;
+use super::types::{InstalledMod, ModFolder};
+use crate::commands::nexus::{self, NexusContentQuery};
+use tauri::AppHandle;
 
 /// Builds the Nexus content query for an installed mod, or None when nothing usable
 /// can be derived (a Directory-unit mod with no folder segment, or a File-unit mod
@@ -30,6 +34,90 @@ pub(crate) fn nexus_content_query_for(
         ModUnit::Directory { .. } => {
             let segment = derive_content_segment(on_disk_filename)?.to_string();
             Some(NexusContentQuery::FolderSegment { segment })
+        }
+    }
+}
+
+/// What attempting Nexus content identification for one installed mod produced.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub enum NexusContentIdentifyOutcome {
+    /// Already identified, already carrying a permanent miss, or nothing queryable
+    /// could be derived (no folder segment, or the file could not be found on disk) —
+    /// nothing was attempted, so nothing was recorded.
+    Skipped,
+    NotFound,
+    Ambiguous,
+    Identified,
+}
+
+/// Attempts to identify one already-installed, unidentified mod against Nexus's
+/// content index (the Tier 3 match). Callers must gate this behind an explicit user
+/// action — never call it from the get_installed hot path — and must persist m
+/// afterward regardless of outcome, since a miss is recorded on m itself via
+/// nexus_content_missed so it is asked at most once.
+pub(crate) async fn identify_via_nexus_content_op(
+    app: &AppHandle,
+    game_id: &str,
+    game_path: &str,
+    folders: &[ModFolder],
+    target: &ScanTarget,
+    m: &mut InstalledMod,
+) -> Result<NexusContentIdentifyOutcome, String> {
+    if m.remote_id.is_some() || m.nexus_content_missed == Some(true) {
+        return Ok(NexusContentIdentifyOutcome::Skipped);
+    }
+
+    let rel = get_folder_path(folders, m.folder_id.as_deref());
+    let active = active_mod_path(game_path, &m.filename, rel.as_deref(), target);
+    let disabled = disabled_mod_path(game_path, &m.filename, rel.as_deref(), target);
+    let path = if active.exists() {
+        active
+    } else if disabled.exists() {
+        disabled
+    } else {
+        return Ok(NexusContentIdentifyOutcome::Skipped);
+    };
+
+    let file_size = match &target.unit {
+        ModUnit::File { .. } => Some(
+            tokio::fs::metadata(&path)
+                .await
+                .map_err(|e| e.to_string())?
+                .len() as i64,
+        ),
+        ModUnit::Directory { .. } => None,
+    };
+
+    let Some(query) = nexus_content_query_for(&target.unit, &m.filename, file_size) else {
+        return Ok(NexusContentIdentifyOutcome::Skipped);
+    };
+
+    let ids =
+        nexus::nexus_lookup_content_mod_ids(app.clone(), game_id.to_string(), query).await?;
+
+    match ids.as_slice() {
+        [] => {
+            m.nexus_content_missed = Some(true);
+            Ok(NexusContentIdentifyOutcome::NotFound)
+        }
+        [mod_id] => {
+            let mod_id = *mod_id;
+            let detail_value = nexus::nexus_get_mod(app.clone(), game_id.to_string(), mod_id).await?;
+            let detail = crate::commands::domain::parse_nexus_detail(detail_value)?;
+            m.source = "nexus".to_string();
+            m.remote_id = Some(mod_id.to_string());
+            m.id = crate::commands::sources::source_native_local_id("nexus", &mod_id.to_string());
+            m.name = detail.name;
+            m.version = detail.version;
+            m.author = Some(detail.user.name);
+            m.thumbnail_url = detail.thumbnail.map(|t| t.file);
+            m.nexus_content_missed = None;
+            Ok(NexusContentIdentifyOutcome::Identified)
+        }
+        _ => {
+            m.nexus_content_missed = Some(true);
+            Ok(NexusContentIdentifyOutcome::Ambiguous)
         }
     }
 }

--- a/apps/desktop/src-tauri/src/commands/mods/tests.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/tests.rs
@@ -343,6 +343,58 @@ fn apply_prefix_already_prefixed() {
     assert_eq!(apply_priority_prefix("012_foo.pak", 3), "003_foo.pak");
 }
 
+// ── recover_published_filename ────────────────────────────────────────────
+
+#[test]
+fn recover_published_filename_strips_priority_prefix() {
+    assert_eq!(
+        recover_published_filename("003_Foo.pak", ".disabled"),
+        "Foo.pak"
+    );
+}
+
+#[test]
+fn recover_published_filename_strips_disabled_suffix() {
+    assert_eq!(
+        recover_published_filename("Foo.pak.disabled", ".disabled"),
+        "Foo.pak"
+    );
+}
+
+#[test]
+fn recover_published_filename_strips_both() {
+    assert_eq!(
+        recover_published_filename("003_Foo.pak.disabled", ".disabled"),
+        "Foo.pak"
+    );
+}
+
+#[test]
+fn recover_published_filename_leaves_a_plain_name_alone() {
+    assert_eq!(recover_published_filename("Foo.pak", ".disabled"), "Foo.pak");
+}
+
+// ── derive_content_segment ────────────────────────────────────────────────
+
+#[test]
+fn derive_content_segment_passes_through_a_bare_folder_name() {
+    assert_eq!(derive_content_segment("Welrod"), Some("Welrod"));
+}
+
+#[test]
+fn derive_content_segment_strips_mod_overrides_prefix() {
+    assert_eq!(
+        derive_content_segment("assets/mod_overrides/Welrod"),
+        Some("Welrod")
+    );
+}
+
+#[test]
+fn derive_content_segment_is_none_for_no_usable_segment() {
+    assert_eq!(derive_content_segment(""), None);
+    assert_eq!(derive_content_segment("assets/mod_overrides/"), None);
+}
+
 #[test]
 fn apply_prefix_zero() {
     assert_eq!(apply_priority_prefix("foo.pak", 0), "000_foo.pak");

--- a/apps/desktop/src-tauri/src/commands/mods/tests.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/tests.rs
@@ -126,6 +126,95 @@ fn recover_dropped_mod_stem_reads_the_zip_entry_for_crime_boss_despite_being_dir
     assert_eq!(stem, "SomeMod-WindowsNoEditor");
 }
 
+// ── apply_nexus_archive_identity ────────────────────────────────────────────
+
+fn sample_nexus_match() -> crate::commands::nexus::NexusHashMatch {
+    crate::commands::nexus::NexusHashMatch {
+        mod_id: 52,
+        file_id: 222,
+        name: "wire name Modrex never uses here".to_string(),
+        version: "wire version Modrex never uses here".to_string(),
+        file_name: "abkarino_RinoHud_P.pak".to_string(),
+        file_size: 1363148,
+    }
+}
+
+fn sample_nexus_detail() -> crate::commands::domain::ModDetail {
+    crate::commands::domain::ModDetail {
+        id: 52,
+        name: "RinoHud".to_string(),
+        desc: String::new(),
+        short_desc: String::new(),
+        version: "1.8".to_string(),
+        downloads: 0,
+        likes: 0,
+        views: 0,
+        published_at: String::new(),
+        bumped_at: String::new(),
+        category_id: 0,
+        has_download: true,
+        disable_mod_managers: None,
+        thumbnail: Some(crate::commands::domain::ModThumbnail {
+            file: "https://example.com/thumb.png".to_string(),
+            has_thumb: None,
+        }),
+        download: None,
+        user: crate::commands::domain::ModUser {
+            id: None,
+            name: "abkarino".to_string(),
+            donation_url: None,
+            avatar: None,
+            avatar_has_thumb: None,
+        },
+        changelog: None,
+        instructions: None,
+        license: None,
+        repo_url: None,
+        donation: None,
+        banner: None,
+        images: vec![],
+        dependencies: vec![],
+        instructs_template: None,
+        tags: vec![],
+        members: vec![],
+    }
+}
+
+#[test]
+fn apply_nexus_archive_identity_overwrites_the_generic_identity() {
+    let mut entry = InstalledMod {
+        uid: "RinoHud".to_string(),
+        id: -12345,
+        name: "abkarino_RinoHud_P 52 1.8 2026-07-02T19-49Z 9QzrVe4KC".to_string(),
+        version: String::new(),
+        update_status: UpdateStatus::Unknown,
+        filename: "003_abkarino_RinoHud_P.pak".to_string(),
+        enabled: true,
+        installed_at: "2024-01-01T00:00:00Z".to_string(),
+        sha256: Some("deadbeef".to_string()),
+        ..InstalledMod::default()
+    };
+
+    apply_nexus_archive_identity(&mut entry, &sample_nexus_match(), &sample_nexus_detail());
+
+    assert_eq!(entry.uid, "nexus:52:222");
+    assert_eq!(entry.name, "RinoHud");
+    assert_eq!(entry.version, "1.8");
+    assert_eq!(entry.update_status, UpdateStatus::Known);
+    assert_eq!(entry.source, "nexus");
+    assert_eq!(entry.remote_id.as_deref(), Some("52"));
+    assert_eq!(entry.file_remote_id.as_deref(), Some("222"));
+    assert_eq!(entry.author.as_deref(), Some("abkarino"));
+    assert_eq!(
+        entry.thumbnail_url.as_deref(),
+        Some("https://example.com/thumb.png")
+    );
+    assert_eq!(entry.file_id, Some(222));
+    // filename and sha256 are install-path decisions, not identity - untouched.
+    assert_eq!(entry.filename, "003_abkarino_RinoHud_P.pak");
+    assert_eq!(entry.sha256.as_deref(), Some("deadbeef"));
+}
+
 // ── list_pak_entries (zip path) ───────────────────────────────────────────────
 
 #[test]

--- a/apps/desktop/src-tauri/src/commands/mods/tests.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/tests.rs
@@ -672,6 +672,47 @@ fn read_state_missing_location_is_none() {
     assert_eq!(state.mods[0].location, None);
 }
 
+// ── InstalledMod.nexus_content_missed field ───────────────────────────────
+
+#[test]
+fn read_state_without_nexus_content_missed_still_deserializes() {
+    let json = r#"{
+        "folders": [],
+        "mods": [{
+            "uid": "42",
+            "id": 100,
+            "name": "Test Mod",
+            "version": "1.0",
+            "filename": "001_Test_Mod.pak",
+            "enabled": true,
+            "installedAt": "2024-01-01T00:00:00Z"
+        }]
+    }"#;
+    let mut f = NamedTempFile::new().unwrap();
+    write!(f, "{}", json).unwrap();
+    let state = read_state(f.path());
+    assert_eq!(state.mods[0].nexus_content_missed, None);
+}
+
+#[test]
+fn nexus_content_missed_survives_a_save_and_read_round_trip() {
+    let temp = TempDir::new().unwrap();
+    let state_path = temp.path().join(".modrex.json");
+    let mods = vec![InstalledMod {
+        uid: "1".to_string(),
+        id: -1,
+        name: "Unidentified".to_string(),
+        filename: "Unidentified".to_string(),
+        installed_at: "2024-01-01T00:00:00Z".to_string(),
+        nexus_content_missed: Some(true),
+        ..InstalledMod::default()
+    }];
+    save_state(&state_path, &ModsState { mods, folders: vec![] });
+
+    let state = read_state(&state_path);
+    assert_eq!(state.mods[0].nexus_content_missed, Some(true));
+}
+
 #[test]
 fn uninstall_mod_keeps_empty_folder() {
     let temp = TempDir::new().unwrap();

--- a/apps/desktop/src-tauri/src/commands/mods/tests.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/tests.rs
@@ -40,6 +40,16 @@ fn is_zip_rejects_empty_file() {
     assert_eq!(detect_archive(f.path()), None);
 }
 
+// ── compute_md5 ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn compute_md5_matches_known_digest() {
+    let mut f = NamedTempFile::new().unwrap();
+    f.write_all(b"hello world").unwrap();
+    let digest = compute_md5(f.path()).await.unwrap();
+    assert_eq!(digest, "5eb63bbbe01eeed093cb22bb8f5acdc3");
+}
+
 // ── list_pak_entries (zip path) ───────────────────────────────────────────────
 
 #[test]

--- a/apps/desktop/src-tauri/src/commands/mods/tests.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/tests.rs
@@ -50,6 +50,82 @@ async fn compute_md5_matches_known_digest() {
     assert_eq!(digest, "5eb63bbbe01eeed093cb22bb8f5acdc3");
 }
 
+// ── recover_dropped_mod_stem ───────────────────────────────────────────────
+
+#[test]
+fn recover_dropped_mod_stem_pulls_the_real_pak_name_out_of_a_zip_wrapper() {
+    // Mirrors a real Nexus website download: the outer zip is named after Nexus's own
+    // download-manager scheme, but the single pak entry inside carries the real name.
+    let zip = make_zip(&[("abkarino_RinoHud_P.pak", b"pak bytes")]);
+    let cfg = engine_for_game("pd3").unwrap();
+    let stem = recover_dropped_mod_stem(
+        &cfg.primary().unit,
+        false,
+        Path::new("irrelevant-for-this-branch"),
+        Some(zip.path()),
+        "abkarino_RinoHud_P 52 1.8 2026-07-02T19-49Z 9QzrVe4KC",
+    );
+    assert_eq!(stem, "abkarino_RinoHud_P");
+}
+
+#[test]
+fn recover_dropped_mod_stem_uses_the_directory_unit_tmp_name() {
+    let cfg = engine_for_game("pd2").unwrap();
+    let stem = recover_dropped_mod_stem(
+        &cfg.primary().unit,
+        false,
+        Path::new("/tmp/modrex-mod-abc123/Welrod"),
+        None,
+        "fallback should not be used",
+    );
+    assert_eq!(stem, "Welrod");
+}
+
+#[test]
+fn recover_dropped_mod_stem_falls_back_for_a_bare_loose_pak() {
+    // No zip wrapper: the dropped file's own OS filename already is the real pak name.
+    let cfg = engine_for_game("pd3").unwrap();
+    let stem = recover_dropped_mod_stem(
+        &cfg.primary().unit,
+        false,
+        Path::new("irrelevant-for-this-branch"),
+        None,
+        "Foo",
+    );
+    assert_eq!(stem, "Foo");
+}
+
+#[test]
+fn recover_dropped_mod_stem_falls_back_when_the_archive_has_more_than_one_pak() {
+    let zip = make_zip(&[("A.pak", b"a"), ("B.pak", b"b")]);
+    let cfg = engine_for_game("pd3").unwrap();
+    let stem = recover_dropped_mod_stem(
+        &cfg.primary().unit,
+        false,
+        Path::new("irrelevant-for-this-branch"),
+        Some(zip.path()),
+        "fallback",
+    );
+    assert_eq!(stem, "fallback");
+}
+
+#[test]
+fn recover_dropped_mod_stem_reads_the_zip_entry_for_crime_boss_despite_being_directory_unit() {
+    // Crime Boss is Directory-unit but its tmp is an opaque synthesized skeleton root with
+    // no usable name of its own - it must take the same zip-entry path as File-unit games,
+    // not the plain Directory-unit tmp.file_name() shortcut.
+    let zip = make_zip(&[("SomeMod-WindowsNoEditor.pak", b"pak bytes")]);
+    let cfg = engine_for_game("cb").unwrap();
+    let stem = recover_dropped_mod_stem(
+        &cfg.primary().unit,
+        true,
+        Path::new("/tmp/modrex-cb-mod-abc123"),
+        Some(zip.path()),
+        "fallback should not be used",
+    );
+    assert_eq!(stem, "SomeMod-WindowsNoEditor");
+}
+
 // ── list_pak_entries (zip path) ───────────────────────────────────────────────
 
 #[test]
@@ -371,7 +447,10 @@ fn recover_published_filename_strips_both() {
 
 #[test]
 fn recover_published_filename_leaves_a_plain_name_alone() {
-    assert_eq!(recover_published_filename("Foo.pak", ".disabled"), "Foo.pak");
+    assert_eq!(
+        recover_published_filename("Foo.pak", ".disabled"),
+        "Foo.pak"
+    );
 }
 
 // ── derive_content_segment ────────────────────────────────────────────────
@@ -707,7 +786,13 @@ fn nexus_content_missed_survives_a_save_and_read_round_trip() {
         nexus_content_missed: Some(true),
         ..InstalledMod::default()
     }];
-    save_state(&state_path, &ModsState { mods, folders: vec![] });
+    save_state(
+        &state_path,
+        &ModsState {
+            mods,
+            folders: vec![],
+        },
+    );
 
     let state = read_state(&state_path);
     assert_eq!(state.mods[0].nexus_content_missed, Some(true));

--- a/apps/desktop/src-tauri/src/commands/mods/types.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/types.rs
@@ -94,6 +94,12 @@ pub struct InstalledMod {
     pub location: Option<String>,
     #[serde(default, skip_serializing_if = "UpdateStatus::is_known")]
     pub update_status: UpdateStatus,
+    // Nexus content-index lookup (nexus_content.rs) found nothing, or an ambiguous
+    // result, for this mod. Persisted so a permanent miss (roughly a quarter of mods
+    // are never indexed) is asked at most once rather than re-queried every attempt.
+    // None means never attempted; Some(false) never occurs and is not written.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub nexus_content_missed: Option<bool>,
 }
 
 impl Default for InstalledMod {
@@ -120,6 +126,7 @@ impl Default for InstalledMod {
             archive_broken: None,
             location: None,
             update_status: UpdateStatus::Known,
+            nexus_content_missed: None,
         }
     }
 }

--- a/apps/desktop/src-tauri/src/commands/mods/zip.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/zip.rs
@@ -3,6 +3,7 @@ use super::host_mods::detect_host_pack;
 use super::paths::{active_mod_path, disabled_mod_path};
 use super::state::get_folder_path;
 use super::types::{InstalledMod, ModFolder};
+use md5::Md5;
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 use std::fs::File;
@@ -258,6 +259,28 @@ pub async fn compute_sha256(path: &Path) -> Result<String, String> {
     tauri::async_runtime::spawn_blocking(move || {
         let mut file = File::open(&path).map_err(|e| e.to_string())?;
         let mut hasher = Sha256::new();
+        let mut buf = vec![0u8; 64 * 1024];
+        loop {
+            let n = file.read(&mut buf).map_err(|e| e.to_string())?;
+            if n == 0 {
+                break;
+            }
+            hasher.update(&buf[..n]);
+        }
+        Ok(hex::encode(hasher.finalize()))
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+// Nexus's fileHash lookup keys on the MD5 of the whole published archive, not the
+// extracted content SHA256 above - the two hashes serve different lookups and are
+// never interchangeable.
+pub async fn compute_md5(path: &Path) -> Result<String, String> {
+    let path = path.to_path_buf();
+    tauri::async_runtime::spawn_blocking(move || {
+        let mut file = File::open(&path).map_err(|e| e.to_string())?;
+        let mut hasher = Md5::new();
         let mut buf = vec![0u8; 64 * 1024];
         loop {
             let n = file.read(&mut buf).map_err(|e| e.to_string())?;

--- a/apps/desktop/src-tauri/src/commands/nexus.rs
+++ b/apps/desktop/src-tauri/src/commands/nexus.rs
@@ -551,7 +551,7 @@ fn parse_content_mod_ids(value: &Value) -> Result<Vec<u32>, String> {
     Ok(ids)
 }
 
-/// Distinct Nexus mod ids whose published content matches `query`. Zero is a normal,
+/// Distinct Nexus mod ids whose published content matches query. Zero is a normal,
 /// expected outcome (roughly a quarter of mods are never indexed) — never treat an
 /// empty result as an error. More than one means the match was not unique; the caller
 /// must not guess which mod it is.

--- a/apps/desktop/src-tauri/src/commands/nexus.rs
+++ b/apps/desktop/src-tauri/src/commands/nexus.rs
@@ -416,6 +416,71 @@ pub(crate) async fn nexus_lookup_by_md5(
     parse_hash_matches(&value, want)
 }
 
+/// What identifying a dropped archive against Nexus produced. Returned in the Ok
+/// channel, mirroring InstallOutcome (mods/mod.rs), so the renderer handles every
+/// case explicitly instead of guessing from an empty list.
+#[derive(Debug, Clone, serde::Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub enum NexusArchiveIdentity {
+    NotFound,
+    Identified(NexusHashMatch),
+    /// The same archive bytes are published under more than one Nexus mod (a real,
+    /// observed shape — cross-posted content) and fileSize could not tell them apart
+    /// because they are, by definition, the same size. The caller must ask the user.
+    Ambiguous(Vec<NexusHashMatch>),
+}
+
+// Never picks a match on its own beyond what the data actually disambiguates: exactly
+// one candidate is the only case that resolves silently. fileSize matching the local
+// archive is a genuine discriminator when fileHashes ever returns candidates of
+// different sizes; when every candidate is the same size (typical, since they are
+// duplicates of the same bytes) this correctly falls through to Ambiguous.
+fn resolve_archive_identity(matches: Vec<NexusHashMatch>, local_size: i64) -> NexusArchiveIdentity {
+    match matches.len() {
+        0 => NexusArchiveIdentity::NotFound,
+        1 => NexusArchiveIdentity::Identified(
+            matches
+                .into_iter()
+                .next()
+                .expect("len checked above"),
+        ),
+        _ => {
+            let mut by_size: Vec<NexusHashMatch> = matches
+                .iter()
+                .filter(|m| m.file_size == local_size)
+                .cloned()
+                .collect();
+            if by_size.len() == 1 {
+                NexusArchiveIdentity::Identified(by_size.remove(0))
+            } else {
+                NexusArchiveIdentity::Ambiguous(matches)
+            }
+        }
+    }
+}
+
+/// Identifies a dropped archive against Nexus before it is installed as an
+/// unidentified entry. The renderer calls this ahead of install_dropped_file; a
+/// NotFound or Ambiguous result still falls through to the existing unidentified
+/// install path, this only ever adds an identity, never blocks one.
+#[tauri::command]
+#[specta::specta]
+pub async fn identify_dropped_archive(
+    app: AppHandle,
+    game_id: String,
+    path: String,
+) -> Result<NexusArchiveIdentity, String> {
+    let file = std::path::PathBuf::from(&path);
+    let local_size = tokio::fs::metadata(&file)
+        .await
+        .map_err(|e| e.to_string())?
+        .len() as i64;
+    let md5 = crate::commands::mods::compute_md5(&file).await?;
+
+    let matches = nexus_lookup_by_md5(app, game_id, vec![md5]).await?;
+    Ok(resolve_archive_identity(matches, local_size))
+}
+
 #[cfg(test)]
 #[path = "nexus_tests.rs"]
 mod tests;

--- a/apps/desktop/src-tauri/src/commands/nexus.rs
+++ b/apps/desktop/src-tauri/src/commands/nexus.rs
@@ -481,6 +481,106 @@ pub async fn identify_dropped_archive(
     Ok(resolve_archive_identity(matches, local_size))
 }
 
+// modFileContents carries no hash, unlike fileHash(es) above — this is the closest
+// legal equivalent to a SHA256 lookup Nexus permits, matching on the file(s) Modrex
+// already has extracted on disk instead of an archive it may no longer hold. Which
+// variant applies is a ModUnit decision, made by the caller in mods/, not here: this
+// module only knows how to ask Nexus each shape of question, not which one a given
+// game's mods need.
+const CONTENT_QUERY: &str = r#"
+query ModrexFileContents($filter: ModFileContentSearchFilter, $count: Int) {
+    modFileContents(filter: $filter, count: $count) {
+        totalCount
+        nodes { modId }
+    }
+}
+"#;
+
+const CONTENT_PAGE_SIZE: u32 = 50;
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum NexusContentQuery {
+    /// File-unit games (PD3, Crime Boss): the .pak's published name and exact byte size.
+    FileNameAndSize { file_name: String, file_size: i64 },
+    /// Directory-unit games (PD2, PDTH, RAID): the mod's folder name as a path segment.
+    FolderSegment { segment: String },
+}
+
+fn content_filter_json(want_game_id: u32, query: &NexusContentQuery) -> Value {
+    let mut filter = serde_json::json!({
+        "gameId": [{ "value": want_game_id, "op": "EQUALS" }],
+    });
+    match query {
+        NexusContentQuery::FileNameAndSize {
+            file_name,
+            file_size,
+        } => {
+            filter["fileNameWildcard"] =
+                serde_json::json!([{ "value": file_name, "op": "EQUALS" }]);
+            // fileSize is a quoted String in the filter input despite the output field
+            // being a BigInt — the opposite convention from gameId above.
+            filter["fileSize"] =
+                serde_json::json!([{ "value": file_size.to_string(), "op": "EQUALS" }]);
+        }
+        NexusContentQuery::FolderSegment { segment } => {
+            filter["filePathPartsExact"] = serde_json::json!([{ "value": segment, "op": "EQUALS" }]);
+        }
+    }
+    filter
+}
+
+fn parse_content_mod_ids(value: &Value) -> Result<Vec<u32>, String> {
+    if let Some(errors) = value.get("errors") {
+        return Err(format!("nexus graphql error: {errors}"));
+    }
+
+    let nodes = value
+        .get("data")
+        .and_then(|d| d.get("modFileContents"))
+        .and_then(|c| c.get("nodes"))
+        .and_then(|n| n.as_array())
+        .ok_or_else(|| "nexus: malformed graphql response".to_string())?;
+
+    let mut ids: Vec<u32> = nodes
+        .iter()
+        .filter_map(|n| n.get("modId").and_then(Value::as_u64))
+        .map(|id| id as u32)
+        .collect();
+    ids.sort_unstable();
+    ids.dedup();
+    Ok(ids)
+}
+
+/// Distinct Nexus mod ids whose published content matches `query`. Zero is a normal,
+/// expected outcome (roughly a quarter of mods are never indexed) — never treat an
+/// empty result as an error. More than one means the match was not unique; the caller
+/// must not guess which mod it is.
+pub(crate) async fn nexus_lookup_content_mod_ids(
+    app: AppHandle,
+    game_id: String,
+    query: NexusContentQuery,
+) -> Result<Vec<u32>, String> {
+    let want = nexus_numeric_game_id(&game_id)?;
+    let headers = nexus_headers(&app).await?;
+    let filter = content_filter_json(want, &query);
+
+    let body = serde_json::json!({
+        "query": CONTENT_QUERY,
+        "variables": { "filter": filter, "count": CONTENT_PAGE_SIZE },
+    });
+
+    let value = send_with_retry("modFileContents", || {
+        let mut req = http_client().post(GRAPHQL_BASE).json(&body);
+        for (k, v) in &headers {
+            req = req.header(*k, v);
+        }
+        req
+    })
+    .await?;
+
+    parse_content_mod_ids(&value)
+}
+
 #[cfg(test)]
 #[path = "nexus_tests.rs"]
 mod tests;

--- a/apps/desktop/src-tauri/src/commands/nexus.rs
+++ b/apps/desktop/src-tauri/src/commands/nexus.rs
@@ -51,6 +51,15 @@ pub(crate) fn game_id_for_domain(domain: &str) -> Result<&'static str, String> {
         .ok_or_else(|| format!("nexus: no game id mapping for domain '{domain}'"))
 }
 
+// The GraphQL content API filters on Nexus's numeric game id, a different id than
+// the domain slug nexus_domain returns. Both name the same game.
+pub(crate) fn nexus_numeric_game_id(game_id: &str) -> Result<u32, String> {
+    sources::source_spec("nexus")
+        .and_then(|s| s.games.iter().find(|g| g.game_id == game_id))
+        .and_then(|g| g.numeric_id)
+        .ok_or_else(|| format!("nexus: no numeric game id for '{game_id}'"))
+}
+
 async fn nexus_headers(app: &AppHandle) -> Result<Vec<(&'static str, String)>, String> {
     let token = nexus_oauth::access_token(app).await?;
     Ok(vec![

--- a/apps/desktop/src-tauri/src/commands/nexus.rs
+++ b/apps/desktop/src-tauri/src/commands/nexus.rs
@@ -324,6 +324,98 @@ pub async fn nexus_search_mods(
     crate::commands::domain::parse_nexus_page(mods, page as i64, PAGE_SIZE as i64)
 }
 
+// fileHash is the archive-level lookup: the MD5 of the whole published archive as
+// uploaded, not the extracted-content SHA256 Modrex already tracks. modFile.version
+// is a real, populated version here (unlike SEARCH_QUERY's mods, which carries none —
+// see the empty-version note in domain.rs), so a hit from this path may set version.
+const FILE_HASHES_QUERY: &str = r#"
+query ModrexFileHashes($md5s: [String]!) {
+    fileHashes(md5s: $md5s) {
+        md5 fileName fileSize gameId modFileId
+        modFile { modId fileId name version }
+    }
+}
+"#;
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct NexusHashMatch {
+    pub mod_id: u32,
+    pub file_id: u32,
+    pub name: String,
+    pub version: String,
+    pub file_name: String,
+    pub file_size: i64,
+}
+
+// BigInt scalars (fileSize here) are not guaranteed to arrive as a JSON number —
+// some GraphQL servers serialize them as a string to avoid JS float-precision loss
+// on large values, matching the quoted-string convention the input filter already
+// uses for the same field (see the modFileContents fileSize filter note).
+fn parse_big_int(value: &Value) -> Option<i64> {
+    value.as_i64().or_else(|| value.as_str()?.parse().ok())
+}
+
+fn parse_hash_matches(value: &Value, want_game_id: u32) -> Result<Vec<NexusHashMatch>, String> {
+    if let Some(errors) = value.get("errors") {
+        return Err(format!("nexus graphql error: {errors}"));
+    }
+
+    let hashes = value
+        .get("data")
+        .and_then(|d| d.get("fileHashes"))
+        .and_then(|h| h.as_array())
+        .ok_or_else(|| "nexus: malformed graphql response".to_string())?;
+
+    // A hash Nexus has seen but never associated with a mod file carries no
+    // modFile; that is a real "not identifiable this way" outcome, not a
+    // parse failure, so it is dropped rather than erroring the whole lookup.
+    Ok(hashes
+        .iter()
+        .filter(|h| h.get("gameId").and_then(Value::as_u64) == Some(want_game_id as u64))
+        .filter_map(|h| {
+            let mod_file = h.get("modFile")?;
+            Some(NexusHashMatch {
+                mod_id: mod_file.get("modId")?.as_u64()? as u32,
+                file_id: mod_file.get("fileId")?.as_u64()? as u32,
+                name: mod_file.get("name")?.as_str()?.to_string(),
+                version: mod_file.get("version")?.as_str()?.to_string(),
+                file_name: h.get("fileName")?.as_str()?.to_string(),
+                file_size: parse_big_int(h.get("fileSize")?)?,
+            })
+        })
+        .collect())
+}
+
+// Per-archive identification: given the whole downloaded archive's MD5, find the
+// Nexus mod(s) it belongs to. Only ever the current game's matches are returned —
+// discarding a cross-game gameId is the same isolation mod_index.rs enforces via
+// games.name, and it matters here because Nexus's md5 index is global.
+pub(crate) async fn nexus_lookup_by_md5(
+    app: AppHandle,
+    game_id: String,
+    md5s: Vec<String>,
+) -> Result<Vec<NexusHashMatch>, String> {
+    let want = nexus_numeric_game_id(&game_id)?;
+    let headers = nexus_headers(&app).await?;
+
+    let body = serde_json::json!({
+        "query": FILE_HASHES_QUERY,
+        "variables": { "md5s": md5s },
+    });
+
+    let value = send_with_retry("fileHashes", || {
+        let mut req = http_client().post(GRAPHQL_BASE).json(&body);
+        for (k, v) in &headers {
+            req = req.header(*k, v);
+        }
+        req
+    })
+    .await?;
+
+    parse_hash_matches(&value, want)
+}
+
 #[cfg(test)]
 #[path = "nexus_tests.rs"]
 mod tests;

--- a/apps/desktop/src-tauri/src/commands/nexus.rs
+++ b/apps/desktop/src-tauri/src/commands/nexus.rs
@@ -438,12 +438,9 @@ pub enum NexusArchiveIdentity {
 fn resolve_archive_identity(matches: Vec<NexusHashMatch>, local_size: i64) -> NexusArchiveIdentity {
     match matches.len() {
         0 => NexusArchiveIdentity::NotFound,
-        1 => NexusArchiveIdentity::Identified(
-            matches
-                .into_iter()
-                .next()
-                .expect("len checked above"),
-        ),
+        1 => {
+            NexusArchiveIdentity::Identified(matches.into_iter().next().expect("len checked above"))
+        }
         _ => {
             let mut by_size: Vec<NexusHashMatch> = matches
                 .iter()
@@ -491,7 +488,7 @@ const CONTENT_QUERY: &str = r#"
 query ModrexFileContents($filter: ModFileContentSearchFilter, $count: Int) {
     modFileContents(filter: $filter, count: $count) {
         totalCount
-        nodes { modId }
+        nodes { modId fileSize }
     }
 }
 "#;
@@ -500,36 +497,58 @@ const CONTENT_PAGE_SIZE: u32 = 50;
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum NexusContentQuery {
-    /// File-unit games (PD3, Crime Boss): the .pak's published name and exact byte size.
+    /// File-unit games (PD3, Crime Boss): the .pak's published name. fileSize is not
+    /// sent as a filter (see content_filter_json) — it is only used client-side, and
+    /// only when the name alone is ambiguous.
     FileNameAndSize { file_name: String, file_size: i64 },
     /// Directory-unit games (PD2, PDTH, RAID): the mod's folder name as a path segment.
     FolderSegment { segment: String },
 }
 
+// fileSize is deliberately never sent as a Nexus-side filter for FileNameAndSize: a
+// mod's currently-published file is often a newer upload than what's installed
+// locally, so an exact byte-size match against the live index silently rejects a
+// fileName match that is otherwise unique (confirmed live: a real installed archive's
+// byte size no longer matched Nexus's current index for that same mod, even though
+// its fileName alone resolved to exactly one mod). fileSize is still requested in the
+// response and used to disambiguate client-side, only when fileName alone returns
+// more than one candidate — see parse_content_mod_ids.
 fn content_filter_json(want_game_id: u32, query: &NexusContentQuery) -> Value {
     let mut filter = serde_json::json!({
         "gameId": [{ "value": want_game_id, "op": "EQUALS" }],
     });
     match query {
-        NexusContentQuery::FileNameAndSize {
-            file_name,
-            file_size,
-        } => {
+        NexusContentQuery::FileNameAndSize { file_name, .. } => {
             filter["fileNameWildcard"] =
                 serde_json::json!([{ "value": file_name, "op": "EQUALS" }]);
-            // fileSize is a quoted String in the filter input despite the output field
-            // being a BigInt — the opposite convention from gameId above.
-            filter["fileSize"] =
-                serde_json::json!([{ "value": file_size.to_string(), "op": "EQUALS" }]);
         }
         NexusContentQuery::FolderSegment { segment } => {
-            filter["filePathPartsExact"] = serde_json::json!([{ "value": segment, "op": "EQUALS" }]);
+            filter["filePathPartsExact"] =
+                serde_json::json!([{ "value": segment, "op": "EQUALS" }]);
         }
     }
     filter
 }
 
-fn parse_content_mod_ids(value: &Value) -> Result<Vec<u32>, String> {
+fn content_node_ids(nodes: &[Value]) -> Vec<u32> {
+    let mut ids: Vec<u32> = nodes
+        .iter()
+        .filter_map(|n| n.get("modId").and_then(Value::as_u64))
+        .map(|id| id as u32)
+        .collect();
+    ids.sort_unstable();
+    ids.dedup();
+    ids
+}
+
+/// `disambiguate_by_size` is the local file's byte size for a FileNameAndSize query,
+/// None for FolderSegment (which has no analogous per-node signal to fall back on).
+/// Only consulted when fileName alone returns more than one distinct mod — see
+/// content_filter_json for why fileSize is never sent as a request filter.
+fn parse_content_mod_ids(
+    value: &Value,
+    disambiguate_by_size: Option<i64>,
+) -> Result<Vec<u32>, String> {
     if let Some(errors) = value.get("errors") {
         return Err(format!("nexus graphql error: {errors}"));
     }
@@ -541,14 +560,25 @@ fn parse_content_mod_ids(value: &Value) -> Result<Vec<u32>, String> {
         .and_then(|n| n.as_array())
         .ok_or_else(|| "nexus: malformed graphql response".to_string())?;
 
-    let mut ids: Vec<u32> = nodes
+    let ids = content_node_ids(nodes);
+    let (Some(target_size), true) = (disambiguate_by_size, ids.len() > 1) else {
+        return Ok(ids);
+    };
+
+    let size_matched_nodes: Vec<Value> = nodes
         .iter()
-        .filter_map(|n| n.get("modId").and_then(Value::as_u64))
-        .map(|id| id as u32)
+        .filter(|n| {
+            n.get("fileSize")
+                .and_then(parse_big_int)
+                .is_some_and(|s| s == target_size)
+        })
+        .cloned()
         .collect();
-    ids.sort_unstable();
-    ids.dedup();
-    Ok(ids)
+    let by_size = content_node_ids(&size_matched_nodes);
+    // A miss here just means the fileSize signal did not narrow it down further
+    // (e.g. none of the candidates' currently-indexed size matches) — fall back to
+    // the full name-matched set rather than manufacturing a false empty result.
+    Ok(if by_size.len() == 1 { by_size } else { ids })
 }
 
 /// Distinct Nexus mod ids whose published content matches query. Zero is a normal,
@@ -563,6 +593,10 @@ pub(crate) async fn nexus_lookup_content_mod_ids(
     let want = nexus_numeric_game_id(&game_id)?;
     let headers = nexus_headers(&app).await?;
     let filter = content_filter_json(want, &query);
+    let disambiguate_by_size = match &query {
+        NexusContentQuery::FileNameAndSize { file_size, .. } => Some(*file_size),
+        NexusContentQuery::FolderSegment { .. } => None,
+    };
 
     let body = serde_json::json!({
         "query": CONTENT_QUERY,
@@ -578,7 +612,7 @@ pub(crate) async fn nexus_lookup_content_mod_ids(
     })
     .await?;
 
-    parse_content_mod_ids(&value)
+    parse_content_mod_ids(&value, disambiguate_by_size)
 }
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/src/commands/nexus.rs
+++ b/apps/desktop/src-tauri/src/commands/nexus.rs
@@ -456,10 +456,29 @@ fn resolve_archive_identity(matches: Vec<NexusHashMatch>, local_size: i64) -> Ne
     }
 }
 
-/// Identifies a dropped archive against Nexus before it is installed as an
-/// unidentified entry. The renderer calls this ahead of install_dropped_file; a
-/// NotFound or Ambiguous result still falls through to the existing unidentified
-/// install path, this only ever adds an identity, never blocks one.
+/// Identifies a whole archive file against Nexus's fileHash index by MD5. Shared by
+/// the renderer-facing identify_dropped_archive command and install_dropped_file's own
+/// best-effort identification at install time (mods/mod.rs), so both go through the
+/// same disambiguation rule instead of duplicating it.
+pub(crate) async fn identify_archive_by_md5(
+    app: AppHandle,
+    game_id: String,
+    file: &std::path::Path,
+) -> Result<NexusArchiveIdentity, String> {
+    let local_size = tokio::fs::metadata(file)
+        .await
+        .map_err(|e| e.to_string())?
+        .len() as i64;
+    let md5 = crate::commands::mods::compute_md5(file).await?;
+
+    let matches = nexus_lookup_by_md5(app, game_id, vec![md5]).await?;
+    Ok(resolve_archive_identity(matches, local_size))
+}
+
+/// Renderer-facing wrapper for a dropped file the user is about to install manually
+/// (e.g. from a picker UI) rather than through install_dropped_file's own automatic
+/// attempt. A NotFound or Ambiguous result is not an error — the caller falls through
+/// to the existing unidentified install path either way.
 #[tauri::command]
 #[specta::specta]
 pub async fn identify_dropped_archive(
@@ -467,15 +486,7 @@ pub async fn identify_dropped_archive(
     game_id: String,
     path: String,
 ) -> Result<NexusArchiveIdentity, String> {
-    let file = std::path::PathBuf::from(&path);
-    let local_size = tokio::fs::metadata(&file)
-        .await
-        .map_err(|e| e.to_string())?
-        .len() as i64;
-    let md5 = crate::commands::mods::compute_md5(&file).await?;
-
-    let matches = nexus_lookup_by_md5(app, game_id, vec![md5]).await?;
-    Ok(resolve_archive_identity(matches, local_size))
+    identify_archive_by_md5(app, game_id, std::path::Path::new(&path)).await
 }
 
 // modFileContents carries no hash, unlike fileHash(es) above — this is the closest

--- a/apps/desktop/src-tauri/src/commands/nexus_tests.rs
+++ b/apps/desktop/src-tauri/src/commands/nexus_tests.rs
@@ -166,7 +166,10 @@ fn resolve_archive_identity_stays_ambiguous_when_size_matches_none() {
 }
 
 #[test]
-fn content_filter_json_sends_game_id_unquoted_and_file_size_quoted() {
+fn content_filter_json_sends_game_id_unquoted_and_never_filters_on_file_size() {
+    // fileSize must never be sent as a Nexus-side filter for FileNameAndSize - see
+    // content_filter_json's own doc comment for why (a real installed file's byte size
+    // can legitimately differ from Nexus's currently-indexed version of the same mod).
     let filter = content_filter_json(
         648,
         &NexusContentQuery::FileNameAndSize {
@@ -176,7 +179,7 @@ fn content_filter_json_sends_game_id_unquoted_and_file_size_quoted() {
     );
     assert_eq!(filter["gameId"][0]["value"], serde_json::json!(648));
     assert_eq!(filter["fileNameWildcard"][0]["value"], "Foo.pak");
-    assert_eq!(filter["fileSize"][0]["value"], "1234");
+    assert!(filter.get("fileSize").is_none());
 }
 
 #[test]
@@ -198,7 +201,7 @@ fn parse_content_mod_ids_returns_distinct_sorted_ids() {
             { "modId": 101 }, { "modId": 202 }, { "modId": 101 }
         ] } }
     });
-    assert_eq!(parse_content_mod_ids(&value).unwrap(), vec![101, 202]);
+    assert_eq!(parse_content_mod_ids(&value, None).unwrap(), vec![101, 202]);
 }
 
 #[test]
@@ -206,14 +209,61 @@ fn parse_content_mod_ids_empty_is_not_an_error() {
     let value = serde_json::json!({
         "data": { "modFileContents": { "totalCount": 0, "nodes": [] } }
     });
-    assert_eq!(parse_content_mod_ids(&value).unwrap(), Vec::<u32>::new());
+    assert_eq!(
+        parse_content_mod_ids(&value, None).unwrap(),
+        Vec::<u32>::new()
+    );
 }
 
 #[test]
 fn parse_content_mod_ids_surfaces_graphql_errors() {
     let value = serde_json::json!({ "errors": [{ "message": "boom" }] });
-    let err = parse_content_mod_ids(&value).unwrap_err();
+    let err = parse_content_mod_ids(&value, None).unwrap_err();
     assert!(err.contains("boom"));
+}
+
+#[test]
+fn parse_content_mod_ids_a_unique_name_match_needs_no_size_disambiguation() {
+    // The real bug this guards against: fileName alone resolved to exactly one mod,
+    // but that mod's currently-indexed fileSize no longer matches the local file (a
+    // newer upload since the user's copy was downloaded). Must still return the id.
+    let value = serde_json::json!({
+        "data": { "modFileContents": { "totalCount": 1, "nodes": [
+            { "modId": 52, "fileSize": "1363148" }
+        ] } }
+    });
+    assert_eq!(
+        parse_content_mod_ids(&value, Some(1340430)).unwrap(),
+        vec![52]
+    );
+}
+
+#[test]
+fn parse_content_mod_ids_disambiguates_multiple_name_matches_by_size() {
+    let value = serde_json::json!({
+        "data": { "modFileContents": { "totalCount": 2, "nodes": [
+            { "modId": 101, "fileSize": "468" },
+            { "modId": 202, "fileSize": "900" }
+        ] } }
+    });
+    assert_eq!(parse_content_mod_ids(&value, Some(468)).unwrap(), vec![101]);
+}
+
+#[test]
+fn parse_content_mod_ids_stays_ambiguous_when_size_matches_none_or_several() {
+    let value = serde_json::json!({
+        "data": { "modFileContents": { "totalCount": 2, "nodes": [
+            { "modId": 101, "fileSize": "468" },
+            { "modId": 202, "fileSize": "900" }
+        ] } }
+    });
+    // No candidate has this size: falls back to the full name-matched set.
+    assert_eq!(
+        parse_content_mod_ids(&value, Some(111)).unwrap(),
+        vec![101, 202]
+    );
+    // No target size at all (FolderSegment queries): same fallback.
+    assert_eq!(parse_content_mod_ids(&value, None).unwrap(), vec![101, 202]);
 }
 
 #[test]

--- a/apps/desktop/src-tauri/src/commands/nexus_tests.rs
+++ b/apps/desktop/src-tauri/src/commands/nexus_tests.rs
@@ -106,6 +106,65 @@ fn parse_hash_matches_surfaces_graphql_errors() {
     assert!(err.contains("boom"));
 }
 
+fn sample_match(mod_id: u32, file_size: i64) -> NexusHashMatch {
+    NexusHashMatch {
+        mod_id,
+        file_id: mod_id + 1000,
+        name: format!("mod-{mod_id}"),
+        version: "1.0".to_string(),
+        file_name: "Foo.pak".to_string(),
+        file_size,
+    }
+}
+
+#[test]
+fn resolve_archive_identity_finds_nothing() {
+    let result = resolve_archive_identity(vec![], 100);
+    assert!(matches!(result, NexusArchiveIdentity::NotFound));
+}
+
+#[test]
+fn resolve_archive_identity_identifies_a_single_match() {
+    let result = resolve_archive_identity(vec![sample_match(101, 468)], 468);
+    match result {
+        NexusArchiveIdentity::Identified(m) => assert_eq!(m.mod_id, 101),
+        other => panic!("expected Identified, got {other:?}"),
+    }
+}
+
+#[test]
+fn resolve_archive_identity_disambiguates_by_local_file_size() {
+    let matches = vec![sample_match(101, 468), sample_match(202, 900)];
+    let result = resolve_archive_identity(matches, 468);
+    match result {
+        NexusArchiveIdentity::Identified(m) => assert_eq!(m.mod_id, 101),
+        other => panic!("expected Identified, got {other:?}"),
+    }
+}
+
+#[test]
+fn resolve_archive_identity_stays_ambiguous_when_sizes_all_match_the_same_bytes() {
+    // The realistic case: the same archive cross-posted to two different mods has
+    // identical fileSize on both, so size cannot discriminate and a chooser is
+    // the only correct outcome.
+    let matches = vec![sample_match(101, 468), sample_match(202, 468)];
+    let result = resolve_archive_identity(matches, 468);
+    match result {
+        NexusArchiveIdentity::Ambiguous(m) => assert_eq!(m.len(), 2),
+        other => panic!("expected Ambiguous, got {other:?}"),
+    }
+}
+
+#[test]
+fn resolve_archive_identity_stays_ambiguous_when_size_matches_none() {
+    let matches = vec![sample_match(101, 468), sample_match(202, 900)];
+    let result = resolve_archive_identity(matches, 111);
+    match result {
+        NexusArchiveIdentity::Ambiguous(m) => assert_eq!(m.len(), 2),
+        other => panic!("expected Ambiguous, got {other:?}"),
+    }
+}
+
 #[test]
 fn parse_hash_matches_drops_hashes_with_no_associated_mod_file() {
     let value = serde_json::json!({

--- a/apps/desktop/src-tauri/src/commands/nexus_tests.rs
+++ b/apps/desktop/src-tauri/src/commands/nexus_tests.rs
@@ -166,6 +166,57 @@ fn resolve_archive_identity_stays_ambiguous_when_size_matches_none() {
 }
 
 #[test]
+fn content_filter_json_sends_game_id_unquoted_and_file_size_quoted() {
+    let filter = content_filter_json(
+        648,
+        &NexusContentQuery::FileNameAndSize {
+            file_name: "Foo.pak".to_string(),
+            file_size: 1234,
+        },
+    );
+    assert_eq!(filter["gameId"][0]["value"], serde_json::json!(648));
+    assert_eq!(filter["fileNameWildcard"][0]["value"], "Foo.pak");
+    assert_eq!(filter["fileSize"][0]["value"], "1234");
+}
+
+#[test]
+fn content_filter_json_folder_segment_uses_file_path_parts_exact() {
+    let filter = content_filter_json(
+        648,
+        &NexusContentQuery::FolderSegment {
+            segment: "Welrod".to_string(),
+        },
+    );
+    assert_eq!(filter["filePathPartsExact"][0]["value"], "Welrod");
+    assert!(filter.get("fileNameWildcard").is_none());
+}
+
+#[test]
+fn parse_content_mod_ids_returns_distinct_sorted_ids() {
+    let value = serde_json::json!({
+        "data": { "modFileContents": { "totalCount": 3, "nodes": [
+            { "modId": 101 }, { "modId": 202 }, { "modId": 101 }
+        ] } }
+    });
+    assert_eq!(parse_content_mod_ids(&value).unwrap(), vec![101, 202]);
+}
+
+#[test]
+fn parse_content_mod_ids_empty_is_not_an_error() {
+    let value = serde_json::json!({
+        "data": { "modFileContents": { "totalCount": 0, "nodes": [] } }
+    });
+    assert_eq!(parse_content_mod_ids(&value).unwrap(), Vec::<u32>::new());
+}
+
+#[test]
+fn parse_content_mod_ids_surfaces_graphql_errors() {
+    let value = serde_json::json!({ "errors": [{ "message": "boom" }] });
+    let err = parse_content_mod_ids(&value).unwrap_err();
+    assert!(err.contains("boom"));
+}
+
+#[test]
 fn parse_hash_matches_drops_hashes_with_no_associated_mod_file() {
     let value = serde_json::json!({
         "data": {

--- a/apps/desktop/src-tauri/src/commands/nexus_tests.rs
+++ b/apps/desktop/src-tauri/src/commands/nexus_tests.rs
@@ -46,3 +46,82 @@ fn sort_field_rejects_unknown_values() {
     assert!(validate_sort_field("name").is_err());
     assert!(validate_sort_field("").is_err());
 }
+
+fn sample_hash_response() -> serde_json::Value {
+    serde_json::json!({
+        "data": {
+            "fileHashes": [
+                {
+                    "md5": "abc123",
+                    "fileName": "Welrod.pak",
+                    "fileSize": "468",
+                    "gameId": 648,
+                    "modFileId": 111,
+                    "modFile": {
+                        "modId": 101,
+                        "fileId": 222,
+                        "name": "Welrod",
+                        "version": "1.0"
+                    }
+                },
+                {
+                    "md5": "def456",
+                    "fileName": "OtherGame.pak",
+                    "fileSize": "999",
+                    "gameId": 5717,
+                    "modFileId": 333,
+                    "modFile": {
+                        "modId": 900,
+                        "fileId": 901,
+                        "name": "Wrong Game Mod",
+                        "version": "2.0"
+                    }
+                }
+            ]
+        }
+    })
+}
+
+#[test]
+fn parse_hash_matches_keeps_only_the_requested_game() {
+    let matches = parse_hash_matches(&sample_hash_response(), 648).unwrap();
+    assert_eq!(matches.len(), 1);
+    assert_eq!(matches[0].mod_id, 101);
+    assert_eq!(matches[0].file_id, 222);
+    assert_eq!(matches[0].name, "Welrod");
+    assert_eq!(matches[0].version, "1.0");
+    assert_eq!(matches[0].file_size, 468);
+}
+
+#[test]
+fn parse_hash_matches_returns_empty_for_a_game_with_no_hits() {
+    let matches = parse_hash_matches(&sample_hash_response(), 4339).unwrap();
+    assert!(matches.is_empty());
+}
+
+#[test]
+fn parse_hash_matches_surfaces_graphql_errors() {
+    let value = serde_json::json!({ "errors": [{ "message": "boom" }] });
+    let err = parse_hash_matches(&value, 648).unwrap_err();
+    assert!(err.contains("boom"));
+}
+
+#[test]
+fn parse_hash_matches_drops_hashes_with_no_associated_mod_file() {
+    let value = serde_json::json!({
+        "data": {
+            "fileHashes": [
+                {
+                    "md5": "abc123",
+                    "fileName": "Unknown.pak",
+                    "fileSize": "1",
+                    "gameId": 648,
+                    "modFileId": null,
+                    "modFile": null
+                }
+            ]
+        }
+    });
+    let matches = parse_hash_matches(&value, 648).unwrap();
+    assert!(matches.is_empty());
+}

--- a/apps/desktop/src-tauri/src/commands/sources.rs
+++ b/apps/desktop/src-tauri/src/commands/sources.rs
@@ -9,6 +9,11 @@ pub struct SourceGame {
     /// What this source calls the game: modworkshop's numeric game id, Nexus's
     /// domain slug. Stored as a string because the two are not the same kind of id.
     pub native_id: &'static str,
+    /// Nexus's GraphQL content API (modFileContents) filters on a numeric game id,
+    /// while its REST API and nxm:// links name the game by the domain slug in
+    /// native_id. Only Nexus has two names for one game, so this is None for every
+    /// other source.
+    pub numeric_id: Option<u32>,
 }
 
 pub struct SourceSpec {
@@ -23,22 +28,27 @@ pub static SOURCE_REGISTRY: &[SourceSpec] = &[
             SourceGame {
                 game_id: "pd3",
                 native_id: "853",
+                numeric_id: None,
             },
             SourceGame {
                 game_id: "pd2",
                 native_id: "1",
+                numeric_id: None,
             },
             SourceGame {
                 game_id: "pdth",
                 native_id: "2",
+                numeric_id: None,
             },
             SourceGame {
                 game_id: "cb",
                 native_id: "857",
+                numeric_id: None,
             },
             SourceGame {
                 game_id: "raid",
                 native_id: "543",
+                numeric_id: None,
             },
         ],
     },
@@ -48,18 +58,22 @@ pub static SOURCE_REGISTRY: &[SourceSpec] = &[
             SourceGame {
                 game_id: "pd3",
                 native_id: "payday3",
+                numeric_id: Some(5717),
             },
             SourceGame {
                 game_id: "pd2",
                 native_id: "payday2",
+                numeric_id: Some(648),
             },
             SourceGame {
                 game_id: "pdth",
                 native_id: "paydaytheheist",
+                numeric_id: Some(4339),
             },
             SourceGame {
                 game_id: "cb",
                 native_id: "crimebossrockaycity",
+                numeric_id: Some(6528),
             },
         ],
     },
@@ -267,5 +281,38 @@ mod tests {
         assert_eq!(native_id("nexus", "no-such-game"), None);
         // Nexus has no RAID presence, so that must not resolve.
         assert_eq!(native_id("nexus", "raid"), None);
+    }
+
+    #[test]
+    fn every_nexus_game_has_a_numeric_id() {
+        let nexus = source_spec("nexus").expect("nexus registered");
+        for game in nexus.games {
+            assert!(
+                game.numeric_id.is_some(),
+                "nexus:{} has no numeric_id, so modFileContents lookups can't filter on it",
+                game.game_id
+            );
+        }
+    }
+
+    #[test]
+    fn every_modworkshop_game_has_no_numeric_id() {
+        let modworkshop = source_spec("modworkshop").expect("modworkshop registered");
+        for game in modworkshop.games {
+            assert!(
+                game.numeric_id.is_none(),
+                "modworkshop:{} has a numeric_id, but only nexus has two names for one game",
+                game.game_id
+            );
+        }
+    }
+
+    #[test]
+    fn nexus_numeric_ids_are_unique() {
+        let nexus = source_spec("nexus").expect("nexus registered");
+        let mut ids: Vec<u32> = nexus.games.iter().filter_map(|g| g.numeric_id).collect();
+        ids.sort_unstable();
+        ids.dedup();
+        assert_eq!(ids.len(), nexus.games.len());
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -64,6 +64,7 @@ fn ipc_builder() -> tauri_specta::Builder<tauri::Wry> {
             commands::mods::install_mod,
             commands::mods::install_file,
             commands::mods::install_dropped_file,
+            commands::mods::identify_mod_via_nexus_content,
             commands::mods::install_from_zip_entry,
             commands::mods::install_cb_flat_archive,
             commands::mods::install_host_pack,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -36,6 +36,7 @@ fn ipc_builder() -> tauri_specta::Builder<tauri::Wry> {
             commands::nexus::nexus_search_mods,
             commands::nexus::nexus_get_mod_detail,
             commands::nexus::nexus_list_mod_files,
+            commands::nexus::identify_dropped_archive,
             commands::nexus_oauth::nexus_oauth_start,
             commands::nexus_oauth::nexus_oauth_signed_in,
             commands::nexus_oauth::nexus_oauth_sign_out,

--- a/apps/desktop/src/renderer/src/api.ts
+++ b/apps/desktop/src/renderer/src/api.ts
@@ -2,8 +2,14 @@ import { listen } from '@tauri-apps/api/event'
 import { getCurrentWindow } from '@tauri-apps/api/window'
 import { getCurrentWebview } from '@tauri-apps/api/webview'
 import { commands, type InstallOutcome } from '../../shared/bindings'
-import type { LoaderInfo, SourceInfo } from '../../shared/bindings'
-export type { InstallOutcome, LoaderInfo, SourceInfo } from '../../shared/bindings'
+import type { LoaderInfo, SourceInfo, NexusArchiveIdentity } from '../../shared/bindings'
+export type {
+    InstallOutcome,
+    LoaderInfo,
+    SourceInfo,
+    NexusArchiveIdentity,
+    NexusHashMatch,
+} from '../../shared/bindings'
 
 // The library declares this union without exporting it.
 export type ResizeDirection = Parameters<
@@ -234,6 +240,12 @@ export const api = {
     // account, only a per-file link to the Nexus site's Mod Manager Download button.
     nexusListModFiles(gameId: string, modId: number): Promise<Paginated<ModFile>> {
         return commands.nexusListModFiles(gameId, modId)
+    },
+    // Archive-level MD5 lookup for a dropped file, ahead of installDroppedFile. A
+    // notFound or ambiguous result is not an error - the caller falls through to
+    // the existing unidentified install path either way.
+    identifyDroppedArchive(gameId: string, path: string): Promise<NexusArchiveIdentity> {
+        return commands.identifyDroppedArchive(gameId, path)
     },
 
     // ── Analytics ────────────────────────────────────────────────────────────────

--- a/apps/desktop/src/renderer/src/api.ts
+++ b/apps/desktop/src/renderer/src/api.ts
@@ -2,13 +2,19 @@ import { listen } from '@tauri-apps/api/event'
 import { getCurrentWindow } from '@tauri-apps/api/window'
 import { getCurrentWebview } from '@tauri-apps/api/webview'
 import { commands, type InstallOutcome } from '../../shared/bindings'
-import type { LoaderInfo, SourceInfo, NexusArchiveIdentity } from '../../shared/bindings'
+import type {
+    LoaderInfo,
+    SourceInfo,
+    NexusArchiveIdentity,
+    NexusContentIdentifyOutcome,
+} from '../../shared/bindings'
 export type {
     InstallOutcome,
     LoaderInfo,
     SourceInfo,
     NexusArchiveIdentity,
     NexusHashMatch,
+    NexusContentIdentifyOutcome,
 } from '../../shared/bindings'
 
 // The library declares this union without exporting it.
@@ -431,6 +437,16 @@ export const api = {
     },
     async disableMod(uid: string, gamePath: string, gameId: string): Promise<void> {
         await commands.disableMod(gamePath, uid, gameId)
+    },
+    // Tier 3 identification, gated behind an explicit user action - never call this
+    // from a background/automatic refresh. A miss is expected for roughly a quarter
+    // of mods and is not an error.
+    identifyModViaNexusContent(
+        uid: string,
+        gamePath: string,
+        gameId: string
+    ): Promise<NexusContentIdentifyOutcome> {
+        return commands.identifyModViaNexusContent(gamePath, uid, gameId)
     },
     async moveCrimeBossModTarget(uid: string, gamePath: string): Promise<void> {
         await commands.moveCrimebossModTarget(gamePath, uid)

--- a/apps/desktop/src/renderer/src/components/InstalledContext.tsx
+++ b/apps/desktop/src/renderer/src/components/InstalledContext.tsx
@@ -28,6 +28,7 @@ export interface InstalledContextValue {
     handleEnable: (mods: InstalledMod[]) => Promise<void>
     handleDisable: (mods: InstalledMod[]) => Promise<void>
     handleReinstall: (mods: InstalledMod[]) => Promise<void>
+    handleIdentifyViaNexus: (mod: InstalledMod) => Promise<void>
     requestMoveCrimeBossTarget: (mod: InstalledMod) => void
     folderActions: FolderActions
     dragItem: DragItem | null

--- a/apps/desktop/src/renderer/src/components/InstalledModItem.tsx
+++ b/apps/desktop/src/renderer/src/components/InstalledModItem.tsx
@@ -9,6 +9,7 @@ import { SkeletonListRow } from './SkeletonListRow'
 import { syntheticMod, detailNavArgs, isIdentified } from '../hooks/installedUtils'
 import { useInstalledContext } from './InstalledContext'
 import { ManageFilesModal } from './ManageFilesModal'
+import { hasSource } from '../sources'
 
 export function InstalledModItem({ mods }: { mods: InstalledMod[] }) {
     const {
@@ -26,6 +27,7 @@ export function InstalledModItem({ mods }: { mods: InstalledMod[] }) {
         handleEnable,
         handleDisable,
         handleReinstall,
+        handleIdentifyViaNexus,
         requestMoveCrimeBossTarget,
         onModPointerDown,
         manageFilesKey,
@@ -76,6 +78,13 @@ export function InstalledModItem({ mods }: { mods: InstalledMod[] }) {
         (combined.location === undefined || combined.location === 'paks') &&
         !combined.missing
 
+    // No point offering this for a mod Modrex can't hash (file missing) or one that
+    // already has a real identity — see identify_via_nexus_content_op's own Skipped
+    // outcome, which this mirrors so the menu doesn't offer an action that can't do
+    // anything. RAID has no Nexus presence at all.
+    const canIdentifyViaNexus =
+        !isIdentified(ins) && !combined.missing && hasSource(activeGame, 'nexus')
+
     function renderMenuButton(dropdownSide: 'right' | 'left') {
         return (
             <div ref={menuRef} className="relative">
@@ -102,6 +111,22 @@ export function InstalledModItem({ mods }: { mods: InstalledMod[] }) {
                         >
                             {t('installed.modMenu.manageFiles')}
                         </button>
+                        {canIdentifyViaNexus && (
+                            <>
+                                <div className="h-px bg-border" />
+                                <button
+                                    onClick={(e) => {
+                                        e.stopPropagation()
+                                        setMenuOpen(false)
+                                        void handleIdentifyViaNexus(ins)
+                                    }}
+                                    disabled={isBusy}
+                                    className="w-full text-left px-3 py-2 text-xs text-text hover:bg-surface-hover transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                                >
+                                    {t('installed.modMenu.identify')}
+                                </button>
+                            </>
+                        )}
                         {canMoveCrimeBossTarget && (
                             <>
                                 <div className="h-px bg-border" />
@@ -209,6 +234,22 @@ export function InstalledModItem({ mods }: { mods: InstalledMod[] }) {
                         >
                             {t('installed.modMenu.manageFiles')}
                         </button>
+                        {canIdentifyViaNexus && (
+                            <>
+                                <div className="h-px bg-border" />
+                                <button
+                                    onClick={(e) => {
+                                        e.stopPropagation()
+                                        setMenuOpen(false)
+                                        void handleIdentifyViaNexus(ins)
+                                    }}
+                                    disabled={isBusy}
+                                    className="w-full text-left px-3 py-2 text-xs text-text hover:bg-surface-hover transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                                >
+                                    {t('installed.modMenu.identify')}
+                                </button>
+                            </>
+                        )}
                         {canMoveCrimeBossTarget && (
                             <>
                                 <div className="h-px bg-border" />

--- a/apps/desktop/src/renderer/src/components/InstalledPage.tsx
+++ b/apps/desktop/src/renderer/src/components/InstalledPage.tsx
@@ -31,6 +31,7 @@ import { useModData } from '../hooks/useModData'
 import { useDragDrop } from '../hooks/useDragDrop'
 import { useFolderActions } from '../hooks/useFolderActions'
 import { useModActions } from '../hooks/useModActions'
+import { useAutoIdentifyNexusMods } from '../hooks/useAutoIdentifyNexusMods'
 import {
     computeChildren,
     groupChildren,
@@ -158,11 +159,14 @@ export function InstalledPage({
         movingCrimeBossTarget,
         crimeBossMoveBusy,
         crimeBossMoveError,
+        identifyNexusResult,
+        dismissIdentifyNexusResult,
         handleRefresh,
         handleUninstall,
         handleEnable,
         handleDisable,
         handleReinstall,
+        handleIdentifyViaNexus,
         requestMoveCrimeBossTarget,
         confirmMoveCrimeBossTarget,
         cancelMoveCrimeBossTarget,
@@ -173,6 +177,8 @@ export function InstalledPage({
     useEffect(() => {
         if (zipPickerData || hostPackData || cbFlatArchiveData) setShowHealth(false)
     }, [zipPickerData, hostPackData, cbFlatArchiveData])
+
+    useAutoIdentifyNexusMods({ installed, gamePath, activeGame, onRefreshInstalled })
 
     const folderActions = useFolderActions(gamePath, onRefreshInstalled, activeGame)
 
@@ -265,6 +271,7 @@ export function InstalledPage({
         handleEnable,
         handleDisable,
         handleReinstall,
+        handleIdentifyViaNexus,
         requestMoveCrimeBossTarget,
         folderActions,
         dragItem,
@@ -444,6 +451,23 @@ export function InstalledPage({
                         </span>
                         <button
                             onClick={clearReinstallError}
+                            className="shrink-0 hover:opacity-70 transition-opacity"
+                        >
+                            <X className="w-3.5 h-3.5" />
+                        </button>
+                    </div>
+                )}
+                {identifyNexusResult && (
+                    <div
+                        className={`px-6 py-2 shrink-0 flex items-center justify-between gap-3 border-b text-xs ${
+                            identifyNexusResult.kind === 'error'
+                                ? 'bg-danger/10 border-danger/30 text-danger'
+                                : 'bg-success/10 border-success/30 text-success-text'
+                        }`}
+                    >
+                        <span className="truncate">{identifyNexusResult.message}</span>
+                        <button
+                            onClick={dismissIdentifyNexusResult}
                             className="shrink-0 hover:opacity-70 transition-opacity"
                         >
                             <X className="w-3.5 h-3.5" />

--- a/apps/desktop/src/renderer/src/hooks/useAutoIdentifyNexusMods.ts
+++ b/apps/desktop/src/renderer/src/hooks/useAutoIdentifyNexusMods.ts
@@ -1,0 +1,77 @@
+import { useEffect, useRef } from 'react'
+import type { GameId, InstalledMod } from '../../../shared/types'
+import { isIdentified } from './installedUtils'
+import { hasSource } from '../sources'
+import { waitForForegroundClear } from '../requestPriority'
+import { api } from '../api'
+
+const STAGGER_MS = 2000
+
+interface Options {
+    installed: InstalledMod[]
+    gamePath: string | null
+    activeGame: GameId
+    onRefreshInstalled: () => Promise<void>
+}
+
+// Background counterpart to useModActions' manual "Identify" action: the first time a
+// mod appears unidentified, try Nexus's content index once, automatically. Never
+// re-attempts a mod that already has an outcome recorded (a real identity, or
+// nexusContentMissed) - this only ever covers a mod's first appearance, same
+// precondition identify_via_nexus_content_op itself enforces server-side. Staggered and
+// yielding to foreground activity so it never competes with the user's own browsing or
+// install actions on the shared rate-limited Nexus connection, mirroring
+// nexusModCache.ts's fetchInstalledNexusModsMeta trickle.
+export function useAutoIdentifyNexusMods({
+    installed,
+    gamePath,
+    activeGame,
+    onRefreshInstalled,
+}: Options): void {
+    const attempted = useRef<Set<string>>(new Set())
+    const running = useRef(false)
+
+    useEffect(() => {
+        attempted.current = new Set()
+    }, [activeGame])
+
+    useEffect(() => {
+        if (!gamePath || running.current || !hasSource(activeGame, 'nexus')) return
+        const candidates = installed.filter(
+            (m) =>
+                !isIdentified(m) &&
+                m.nexusContentMissed !== true &&
+                !m.missing &&
+                !attempted.current.has(m.uid)
+        )
+        if (candidates.length === 0) return
+
+        running.current = true
+        let cancelled = false
+
+        void (async () => {
+            for (const mod of candidates) {
+                if (cancelled) break
+                attempted.current.add(mod.uid)
+                await waitForForegroundClear()
+                if (cancelled) break
+                try {
+                    await api.identifyModViaNexusContent(mod.uid, gamePath, activeGame)
+                    await onRefreshInstalled()
+                } catch (e) {
+                    // Best-effort: a background pass must not interrupt the user with a
+                    // failure toast for a mod they never asked about. The manual Identify
+                    // button still surfaces a real error on request.
+                    console.error(`Background Nexus identification failed for ${mod.uid}`, e)
+                }
+                await new Promise((resolve) => setTimeout(resolve, STAGGER_MS))
+            }
+            running.current = false
+        })()
+
+        return () => {
+            cancelled = true
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [installed, gamePath, activeGame])
+}

--- a/apps/desktop/src/renderer/src/hooks/useModActions.ts
+++ b/apps/desktop/src/renderer/src/hooks/useModActions.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { GameId, InstalledMod } from '../../../shared/types'
 import type { ZipMultiPakPayload } from '../components/ZipPickerModal'
 import { installZipPickerEntries } from '../components/ZipPickerModal'
@@ -6,7 +6,10 @@ import type { HostPackPayload } from '../components/HostPackModal'
 import type { CbFlatArchivePayload } from '../components/CrimeBossFlatArchiveModal'
 import { handleInstallOutcome } from '../installSentinels'
 import { entryFilename, stripPriorityPrefix } from './installedUtils'
+import { t } from '../i18n'
 import { api } from '../api'
+
+export type IdentifyNexusResult = { kind: 'done' | 'error'; message: string }
 
 export interface ModActions {
     loadingMod: string | null
@@ -25,11 +28,14 @@ export interface ModActions {
     movingCrimeBossTarget: InstalledMod | null
     crimeBossMoveBusy: boolean
     crimeBossMoveError: string | null
+    identifyNexusResult: IdentifyNexusResult | null
+    dismissIdentifyNexusResult: () => void
     handleRefresh: () => Promise<void>
     handleUninstall: (mods: InstalledMod[]) => Promise<void>
     handleEnable: (mods: InstalledMod[]) => Promise<void>
     handleDisable: (mods: InstalledMod[]) => Promise<void>
     handleReinstall: (mods: InstalledMod[]) => Promise<void>
+    handleIdentifyViaNexus: (mod: InstalledMod) => Promise<void>
     requestMoveCrimeBossTarget: (mod: InstalledMod) => void
     confirmMoveCrimeBossTarget: () => Promise<void>
     cancelMoveCrimeBossTarget: () => void
@@ -54,6 +60,25 @@ export function useModActions(
     const [movingCrimeBossTarget, setMovingCrimeBossTarget] = useState<InstalledMod | null>(null)
     const [crimeBossMoveBusy, setCrimeBossMoveBusy] = useState(false)
     const [crimeBossMoveError, setCrimeBossMoveError] = useState<string | null>(null)
+    const [identifyNexusResult, setIdentifyNexusResult] = useState<IdentifyNexusResult | null>(null)
+    const identifyNexusResultTimer = useRef<number | null>(null)
+
+    function showIdentifyNexusResult(r: IdentifyNexusResult) {
+        if (identifyNexusResultTimer.current) window.clearTimeout(identifyNexusResultTimer.current)
+        setIdentifyNexusResult(r)
+        identifyNexusResultTimer.current = window.setTimeout(
+            () => setIdentifyNexusResult(null),
+            6000
+        )
+    }
+
+    useEffect(
+        () => () => {
+            if (identifyNexusResultTimer.current)
+                window.clearTimeout(identifyNexusResultTimer.current)
+        },
+        []
+    )
 
     async function handleRefresh() {
         setRefreshing(true)
@@ -92,6 +117,50 @@ export function useModActions(
         try {
             for (const m of mods) await api.disableMod(m.uid, gamePath, activeGame)
             await onRefreshInstalled()
+        } finally {
+            setLoadingMod(null)
+        }
+    }
+
+    // Tier 3 identification (see nexus_content.rs): a miss or an ambiguous result is
+    // expected for roughly a quarter of mods, so both surface as an info toast, not an
+    // error — only a genuine request failure does.
+    async function handleIdentifyViaNexus(mod: InstalledMod) {
+        if (!gamePath) return
+        setLoadingMod(mod.uid)
+        try {
+            const outcome = await api.identifyModViaNexusContent(mod.uid, gamePath, activeGame)
+            await onRefreshInstalled()
+            if (outcome === 'notFound') {
+                showIdentifyNexusResult({
+                    kind: 'done',
+                    message: t('installed.identifyNexus.notFound'),
+                })
+            } else if (outcome === 'skipped') {
+                // Reached when a permanent miss was already recorded on an earlier attempt
+                // (identify_via_nexus_content_op never re-queries once nexus_content_missed is
+                // set) - still worth a toast, since a click that visibly does nothing reads as
+                // broken rather than as "nothing new to check".
+                showIdentifyNexusResult({
+                    kind: 'done',
+                    message: t('installed.identifyNexus.alreadyChecked'),
+                })
+            } else if (outcome === 'ambiguous') {
+                showIdentifyNexusResult({
+                    kind: 'done',
+                    message: t('installed.identifyNexus.ambiguous'),
+                })
+            } else if (outcome === 'identified') {
+                showIdentifyNexusResult({
+                    kind: 'done',
+                    message: t('installed.identifyNexus.identified', { name: mod.name }),
+                })
+            }
+        } catch (e) {
+            showIdentifyNexusResult({
+                kind: 'error',
+                message: t('installed.identifyNexus.error', { error: String(e) }),
+            })
         } finally {
             setLoadingMod(null)
         }
@@ -217,11 +286,14 @@ export function useModActions(
         movingCrimeBossTarget,
         crimeBossMoveBusy,
         crimeBossMoveError,
+        identifyNexusResult,
+        dismissIdentifyNexusResult: () => setIdentifyNexusResult(null),
         handleRefresh,
         handleUninstall,
         handleEnable,
         handleDisable,
         handleReinstall,
+        handleIdentifyViaNexus,
         requestMoveCrimeBossTarget,
         confirmMoveCrimeBossTarget,
         cancelMoveCrimeBossTarget,

--- a/apps/desktop/src/renderer/src/i18n/en.json
+++ b/apps/desktop/src/renderer/src/i18n/en.json
@@ -165,7 +165,16 @@
         },
         "modMenu": {
             "open": "Options",
-            "manageFiles": "Manage files"
+            "manageFiles": "Manage files",
+            "identify": "Identify"
+        },
+        "identifyNexus": {
+            "identifying": "Identifying…",
+            "identified": "Identified as \"{name}\"",
+            "notFound": "No match found on Nexus",
+            "ambiguous": "Multiple possible matches found on Nexus",
+            "alreadyChecked": "Already checked against Nexus — no match was found",
+            "error": "Identification failed: {error}"
         },
         "nexusBadge": "Nexus",
         "crimeBossMove": {

--- a/apps/desktop/src/renderer/src/i18n/ru.json
+++ b/apps/desktop/src/renderer/src/i18n/ru.json
@@ -165,7 +165,16 @@
         },
         "modMenu": {
             "open": "Параметры",
-            "manageFiles": "Управление файлами"
+            "manageFiles": "Управление файлами",
+            "identify": "Определить"
+        },
+        "identifyNexus": {
+            "identifying": "Определение…",
+            "identified": "Определено как «{name}»",
+            "notFound": "Совпадений на Nexus не найдено",
+            "ambiguous": "На Nexus найдено несколько возможных совпадений",
+            "alreadyChecked": "Уже проверено на Nexus — совпадений не найдено",
+            "error": "Не удалось определить: {error}"
         },
         "nexusBadge": "Nexus",
         "crimeBossMove": {

--- a/apps/desktop/src/shared/bindings.ts
+++ b/apps/desktop/src/shared/bindings.ts
@@ -84,6 +84,14 @@ export const commands = {
 	 *  temp first so resolution/cleanup never touches the user's original.
 	 */
 	installDroppedFile: (path: string, gamePath: string, folderId: string | null, gameId: string) => __TAURI_INVOKE<InstallOutcome_Serialize>("install_dropped_file", { path, gamePath, folderId, gameId }),
+	/**
+	 *  User-initiated Tier 3 identification (see nexus_content.rs): looks up one already-
+	 *  installed, unidentified mod against Nexus's content index. Never called from
+	 *  get_installed — the renderer calls this per-mod from an explicit "Identify" action,
+	 *  same shape as the ModWorkshop identification pipeline being automatic (SHA256) while
+	 *  this one, lacking a hash to key on, cannot safely be.
+	 */
+	identifyModViaNexusContent: (gamePath: string, uid: string, gameId: string) => __TAURI_INVOKE<NexusContentIdentifyOutcome>("identify_mod_via_nexus_content", { gamePath, uid, gameId }),
 	installFromZipEntry: (args: InstallFromZipEntryArgs) => __TAURI_INVOKE<null>("install_from_zip_entry", { args }),
 	/**
 	 *  Installs a Crime Boss archive whose content has no enclosing folder (every entry sits at the
@@ -329,6 +337,7 @@ export type InstalledMod_Deserialize = {
 	archiveBroken?: boolean | null,
 	location?: string | null,
 	updateStatus?: UpdateStatus,
+	nexusContentMissed?: boolean | null,
 };
 
 export type InstalledMod_Serialize = {
@@ -353,6 +362,7 @@ export type InstalledMod_Serialize = {
 	archiveBroken?: boolean | null,
 	location?: string | null,
 	updateStatus?: UpdateStatus,
+	nexusContentMissed?: boolean | null,
 };
 
 export type InstalledResponse = InstalledResponse_Serialize | InstalledResponse_Deserialize;
@@ -613,6 +623,15 @@ export type NexusArchiveIdentity = "notFound" | ({ identified: NexusHashMatch })
  *  because they are, by definition, the same size. The caller must ask the user.
  */
 ({ ambiguous: NexusHashMatch[] }) & { identified?: never };
+
+/**  What attempting Nexus content identification for one installed mod produced. */
+export type NexusContentIdentifyOutcome = 
+/**
+ *  Already identified, already carrying a permanent miss, or nothing queryable
+ *  could be derived (no folder segment, or the file could not be found on disk) —
+ *  nothing was attempted, so nothing was recorded.
+ */
+"skipped" | "notFound" | "ambiguous" | "identified";
 
 export type NexusHashMatch = {
 	modId: number,

--- a/apps/desktop/src/shared/bindings.ts
+++ b/apps/desktop/src/shared/bindings.ts
@@ -24,6 +24,13 @@ export const commands = {
 	nexusSearchMods: (gameId: string, query: string, sort: string, offset: number | null) => __TAURI_INVOKE<ModPage>("nexus_search_mods", { gameId, query, sort, offset }),
 	nexusGetModDetail: (gameId: string, modId: number) => __TAURI_INVOKE<ModDetail>("nexus_get_mod_detail", { gameId, modId }),
 	nexusListModFiles: (gameId: string, modId: number) => __TAURI_INVOKE<FilePage>("nexus_list_mod_files", { gameId, modId }),
+	/**
+	 *  Identifies a dropped archive against Nexus before it is installed as an
+	 *  unidentified entry. The renderer calls this ahead of install_dropped_file; a
+	 *  NotFound or Ambiguous result still falls through to the existing unidentified
+	 *  install path, this only ever adds an identity, never blocks one.
+	 */
+	identifyDroppedArchive: (gameId: string, path: string) => __TAURI_INVOKE<NexusArchiveIdentity>("identify_dropped_archive", { gameId, path }),
 	nexusOauthStart: () => __TAURI_INVOKE<void>("nexus_oauth_start"),
 	nexusOauthSignedIn: () => __TAURI_INVOKE<boolean>("nexus_oauth_signed_in"),
 	nexusOauthSignOut: () => __TAURI_INVOKE<void>("nexus_oauth_sign_out"),
@@ -592,6 +599,28 @@ export type NewsItem = {
 export type NewsResult = {
 	items: NewsItem[],
 	totalPages: number,
+};
+
+/**
+ *  What identifying a dropped archive against Nexus produced. Returned in the Ok
+ *  channel, mirroring InstallOutcome (mods/mod.rs), so the renderer handles every
+ *  case explicitly instead of guessing from an empty list.
+ */
+export type NexusArchiveIdentity = "notFound" | ({ identified: NexusHashMatch }) & { ambiguous?: never } | 
+/**
+ *  The same archive bytes are published under more than one Nexus mod (a real,
+ *  observed shape — cross-posted content) and fileSize could not tell them apart
+ *  because they are, by definition, the same size. The caller must ask the user.
+ */
+({ ambiguous: NexusHashMatch[] }) & { identified?: never };
+
+export type NexusHashMatch = {
+	modId: number,
+	fileId: number,
+	name: string,
+	version: string,
+	fileName: string,
+	fileSize: number,
 };
 
 export type PageMeta = {

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -186,6 +186,9 @@ export interface InstalledMod {
     // Whether version is comparable. Replaces the old habit of encoding this in the
     // version string itself as "unknown" / "outdated".
     updateStatus?: 'known' | 'unknown' | 'outdated'
+    // Nexus content-index lookup already found nothing (or an ambiguous result) for
+    // this mod — a permanent miss until Nexus indexes it, so it's never re-queried.
+    nexusContentMissed?: boolean
 }
 
 export interface ModsState {

--- a/apps/site/src/components/Features.astro
+++ b/apps/site/src/components/Features.astro
@@ -1,13 +1,20 @@
 ---
 import type { ModIndexStats } from '../lib/mod-index'
+import type { NexusModCounts } from '../lib/nexus-mod-count'
 
 interface Props {
     indexStats: ModIndexStats | null
+    nexusModCounts: NexusModCounts | null
 }
 
-const { indexStats } = Astro.props
+const { indexStats, nexusModCounts } = Astro.props
 const supportedMods = indexStats
     ? new Intl.NumberFormat('en-US').format(indexStats.supportedMods)
+    : null
+// A separate claim from supportedMods, deliberately not summed into it: this counts
+// mods that EXIST on Nexus, not mods Modrex can recognize by hash on your disk.
+const nexusModsAvailable = nexusModCounts
+    ? new Intl.NumberFormat('en-US').format(nexusModCounts.total)
     : null
 
 const features: [string, string, string][] = [
@@ -58,6 +65,14 @@ const features: [string, string, string][] = [
                 <strong data-mod-index-count aria-live="polite">{supportedMods ?? '...'}</strong>
                 <span>known mods Modrex can match automatically</span>
                 <small>Helps Modrex detect mods already in your game folder.</small>
+                {
+                    nexusModsAvailable && (
+                        <small>
+                            Plus <strong class="nexus-count">{nexusModsAvailable}</strong> mods
+                            available on Nexus Mods.
+                        </small>
+                    )
+                }
             </div>
             {
                 features.map(([icon, title, body], index) => (
@@ -173,7 +188,7 @@ const features: [string, string, string][] = [
         font-weight: 700;
     }
 
-    .index-count strong {
+    .index-count > strong {
         font-family: var(--font-display);
         font-size: clamp(52px, 7vw, 76px);
         line-height: 1;
@@ -196,6 +211,11 @@ const features: [string, string, string][] = [
         font-size: 14px;
         font-weight: 400;
         line-height: 1.55;
+    }
+
+    .index-count .nexus-count {
+        color: var(--color-accent-bright);
+        font-weight: 700;
     }
 
     @media (max-width: 860px) {

--- a/apps/site/src/lib/nexus-mod-count.ts
+++ b/apps/site/src/lib/nexus-mod-count.ts
@@ -1,0 +1,70 @@
+import { GAMES } from '@modrex/games'
+
+const NEXUS_GRAPHQL_URL = 'https://api.nexusmods.com/v2/graphql'
+
+// Games Modrex has a Nexus presence for, from the single shared registry - RAID has
+// none and is naturally absent since its nexusDomain is unset. Cross-checked against
+// the Rust SOURCE_REGISTRY by check-sources.mjs.
+const NEXUS_GAME_DOMAINS = new Set(
+    Object.values(GAMES)
+        .map((g) => g.nexusDomain)
+        .filter((d): d is string => d !== undefined)
+)
+
+interface NexusGameNode {
+    domainName: string
+    modCount: number | null
+}
+
+interface NexusGamesResponse {
+    data?: {
+        payday?: { nodes?: NexusGameNode[] }
+        crimeBoss?: { nodes?: NexusGameNode[] }
+    }
+    errors?: unknown
+}
+
+export interface NexusModCounts {
+    total: number
+}
+
+// Build-time only, a single small query (games() with a name filter, no per-mod
+// enumeration), unauthenticated - Nexus's GraphQL API answers introspection and reads
+// without a token (verified live). This is normal, occasional developer/build-time API
+// use, not a production path that depends on the unauthenticated door staying open -
+// see modrex-main's Nexus identification memory for why the desktop app instead routes
+// every request through OAuth. Counts mods that EXIST on Nexus; never sum this into
+// Modrex's own recognized-mod count, which counts mods Modrex can identify by hash.
+export async function getNexusModCounts(): Promise<NexusModCounts | null> {
+    const query = `{
+        payday: games(filter: { name: [{ value: "PAYDAY", op: WILDCARD }] }, count: 10) {
+            nodes { domainName modCount }
+        }
+        crimeBoss: games(filter: { name: [{ value: "Crime Boss", op: WILDCARD }] }, count: 10) {
+            nodes { domainName modCount }
+        }
+    }`
+
+    const res = await fetch(NEXUS_GRAPHQL_URL, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'User-Agent': 'Modrex-Site/1.0 (+https://modrex.net)',
+            'Application-Name': 'Modrex',
+        },
+        body: JSON.stringify({ query }),
+    })
+    if (!res.ok) throw new Error(`Nexus mod count download error: ${res.status}`)
+
+    const body = (await res.json()) as NexusGamesResponse
+    if (body.errors)
+        throw new Error(`Nexus mod count graphql error: ${JSON.stringify(body.errors)}`)
+
+    const nodes = [...(body.data?.payday?.nodes ?? []), ...(body.data?.crimeBoss?.nodes ?? [])]
+    const total = nodes
+        .filter((n) => NEXUS_GAME_DOMAINS.has(n.domainName))
+        .reduce((sum, n) => sum + (n.modCount ?? 0), 0)
+
+    if (total <= 0) return null
+    return { total }
+}

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -10,6 +10,8 @@ import { getLatestRelease, getRecentReleases } from '../lib/github'
 import type { Release } from '../lib/github'
 import { getModIndexStats } from '../lib/mod-index'
 import type { ModIndexStats } from '../lib/mod-index'
+import { getNexusModCounts } from '../lib/nexus-mod-count'
+import type { NexusModCounts } from '../lib/nexus-mod-count'
 
 // Both fetches degrade gracefully (generic download links, no changelog section),
 // but log loudly: without GITHUB_TOKEN set, shared CI build IPs hit GitHub's
@@ -33,6 +35,13 @@ try {
     indexStats = await getModIndexStats()
 } catch (error) {
     console.error('Failed to load mod index stats', error)
+}
+
+let nexusModCounts: NexusModCounts | null = null
+try {
+    nexusModCounts = await getNexusModCounts()
+} catch (error) {
+    console.error('Failed to load Nexus mod counts', error)
 }
 
 const jsonLd = {
@@ -66,7 +75,7 @@ const jsonLd = {
     <script type="application/ld+json" is:inline set:html={JSON.stringify(jsonLd)} slot="head" />
     <Nav release={release} />
     <Hero release={release} />
-    <Features indexStats={indexStats} />
+    <Features indexStats={indexStats} nexusModCounts={nexusModCounts} />
     <DownloadSection release={release} />
     <Changelog releases={recentReleases} />
     <SiteFooter />

--- a/packages/games/index.ts
+++ b/packages/games/index.ts
@@ -12,6 +12,10 @@ export interface GameSpec {
     name: string
     shortName: string
     workshopId: number
+    // Nexus's domain slug for this game, e.g. "payday3". Absent for games with no
+    // Nexus presence (RAID). Cross-checked against the Rust SOURCE_REGISTRY by
+    // check-sources.mjs, same as workshopId.
+    nexusDomain?: string
     storageKey: string
     hasNews: boolean
     requiredLaunchFlag?: string
@@ -24,6 +28,7 @@ const GAME_SPECS = {
         name: 'PAYDAY 3',
         shortName: 'PD3',
         workshopId: 853,
+        nexusDomain: 'payday3',
         storageKey: 'pd3',
         hasNews: true,
         requiredLaunchFlag: '-fileopenlog',
@@ -37,6 +42,7 @@ const GAME_SPECS = {
         name: 'PAYDAY 2',
         shortName: 'PD2',
         workshopId: 1,
+        nexusDomain: 'payday2',
         storageKey: 'pd2',
         hasNews: true,
         launchers: ['Steam', 'Epic Games'],
@@ -49,6 +55,7 @@ const GAME_SPECS = {
         name: 'PAYDAY: The Heist',
         shortName: 'PDTH',
         workshopId: 2,
+        nexusDomain: 'paydaytheheist',
         storageKey: 'pdth',
         hasNews: true,
         launchers: ['Steam'],
@@ -61,6 +68,7 @@ const GAME_SPECS = {
         name: 'Crime Boss: Rockay City',
         shortName: 'CBRC',
         workshopId: 857,
+        nexusDomain: 'crimebossrockaycity',
         storageKey: 'cb',
         hasNews: false,
         launchers: ['Steam', 'Epic Games'],


### PR DESCRIPTION
## Summary

Nexus Mods installs get automatic identification everywhere ModWorkshop already had it, closing the gap that made the Nexus mod counter, update checks, and thumbnails silently unavailable for a large share of installed mods:

- **Drag-and-drop archives**: `install_dropped_file` now MD5-hashes the whole archive and checks it against Nexus's `fileHash` index at install time. A unique match installs the mod already identified (real name, version, author, thumbnail) instead of as "Unknown"; ambiguous or unmatched archives fall through to the existing unidentified-install path unchanged.
- **Already-installed unidentified mods**: a new content-matching engine (`modFileContents`) matches a mod's on-disk filename+size (File-unit games) or folder name (Directory-unit games) against Nexus's published file listings. Runs automatically once per mod the first time it's discovered unidentified (staggered, yields to foreground activity, never on the `get_installed` hot path), and can be retried on demand from a mod's options menu ("Identify").
- **Site**: the homepage's recognized-mod counter now also shows how many mods exist on Nexus for Modrex's supported games, as a separate claim from the ModWorkshop-hash-recognized count.

Two real bugs found and fixed via live testing against real downloaded mods:
- `install_dropped_file` was naming every archive-wrapped drop after the *outer downloaded file* (Nexus's own download-manager filename scheme) instead of the mod's real internal name — this also fed garbage into the new content-matching queries. Fixed by recovering the real name from the archive's own pak entry / extracted folder name.
- The content-matching query sent `fileSize` as a strict filter to Nexus alongside `fileName`. A mod's currently-published file is often a newer upload than what's installed locally, so an exact byte-size match silently rejected an otherwise-unique `fileName` match. `fileSize` is now only used to disambiguate client-side when `fileName` alone returns more than one candidate, never sent as a request filter.

Also adds `nexusDomain` to the shared `@modrex/games` registry (cross-checked against Rust's `SOURCE_REGISTRY` by `check-sources.mjs`) so the site can query Nexus without needing desktop's IPC.

## Test plan

- [x] `cargo test`
- [x] `pnpm test:renderer`
- [x] `cargo clippy`
- [x] `cargo fmt --check`
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm format:check` 
- [x] `check-commands`, `check-i18n`, `check-csp`, `check-sources`
- [x] Regression-tested against two real Nexus downloads (PD3 mods 52 and 239) that initially failed to identify, both bugs above were found and fixed this way
- [x] Manual click-through of the "Identify" button and drag-drop flow in a running app.