### PR TITLE
ci(index): pin upstream 7-Zip 26.02 for RAR4 extraction

### DIFF
--- a/.github/workflows/process-postgres-content.yml
+++ b/.github/workflows/process-postgres-content.yml
@@ -38,7 +38,7 @@ jobs:
                   cache: pnpm
 
             - name: Install system dependencies
-              run: sudo apt-get install -y p7zip-full
+              run: bash apps/index/scripts/install-7zip.sh
 
             - name: Install dependencies
               run: pnpm install --frozen-lockfile

--- a/.github/workflows/refresh-postgres-index.yml
+++ b/.github/workflows/refresh-postgres-index.yml
@@ -56,8 +56,7 @@ jobs:
 
             - name: Install system dependencies
               run: |
-                  sudo apt-get update
-                  sudo apt-get install -y p7zip-full
+                  bash apps/index/scripts/install-7zip.sh
                   curl -fsSL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip
                   unzip -q awscliv2.zip
                   sudo ./aws/install --update

--- a/apps/index/CLAUDE.md
+++ b/apps/index/CLAUDE.md
@@ -28,7 +28,7 @@ node lookup-mod.mjs <name-or-id>        # Look up a mod by name or remote_id (re
 
 > The three `*.mjs` dev utils hardcode a path to the installed app's cached DB (`C:/Users/oleh/AppData/…`). To query a freshly built `index.db` instead, edit the `APP_DB` constant at the top of each file.
 
-`7z` must be on `PATH` — used for 7z and RAR extraction and `.pdmod` decryption. Windows: install from 7-zip.org. Ubuntu CI: `sudo apt-get install p7zip-full`. **`p7zip-full` reads RAR5 but not RAR4**: the older format needs the non-free codec in `p7zip-rar`, and without it every RAR4 download fails extraction, yields no entries, and is then recorded as a checked listing with no files. `markerFromFullArchive` logs each archive it could not open, which is where that shows up.
+`7z` must be on `PATH` — used for 7z and RAR extraction and `.pdmod` decryption. Windows: install from 7-zip.org. Ubuntu CI: `apps/index/scripts/install-7zip.sh`, run by both Postgres workflows before any archive work. Ubuntu's packaged 7-Zip 23.01 (what `p7zip-full`/`p7zip-rar` resolve to on Noble) segfaults decompressing valid RAR4 archives; RAR5/ZIP/7z are unaffected. The script pins upstream 7-Zip 26.02 instead, verifying its checksum and its resolved `--help` banner before adding it ahead of the distro binary on `PATH`. A RAR4 download that still fails extraction is a checked listing with no files; `markerFromFullArchive` logs each archive it could not open. `apps/index/test-archive-canaries.ts` (`pnpm test:archive-canaries`) proves the fix against two real ModWorkshop RAR4 archives that crash the distro binary; it needs network and the pinned extractor, so it runs on demand rather than as part of `index:test`.
 
 ## Architecture
 

--- a/apps/index/package.json
+++ b/apps/index/package.json
@@ -11,6 +11,7 @@
         "report:postgres-coverage": "tsx postgres/report-coverage.ts",
         "sync:postgres-listings": "tsx postgres/sync-listings.ts",
         "verify:postgres-catalog": "tsx postgres/verify-catalog.ts",
+        "test:archive-canaries": "tsx test-archive-canaries.ts",
         "test:export-determinism": "tsx test-export-determinism.ts",
         "test:game-schedule": "tsx test-game-schedule.ts",
         "test:marker-archive": "tsx test-marker-archive.ts",

--- a/apps/index/scripts/install-7zip.sh
+++ b/apps/index/scripts/install-7zip.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Ubuntu's packaged 7-Zip 23.01 (what p7zip-full/p7zip-rar resolve to) segfaults
+# decompressing valid RAR4 archives; RAR5, ZIP and 7z are unaffected. This pins upstream
+# 7-Zip 26.02, which decodes the same archives correctly, instead of the distro package.
+set -euo pipefail
+
+version="26.02"
+url="https://github.com/ip7z/7zip/releases/download/${version}/7z2602-linux-x64.tar.xz"
+sha256="41aaba7b1235304ab5aa0624530c67ae829496cd29e875925271efdccc28c03e"
+
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$work_dir"' EXIT
+
+archive="$work_dir/7zip.tar.xz"
+curl -fsSL -o "$archive" "$url"
+echo "${sha256}  ${archive}" | sha256sum -c -
+
+extract_dir="$work_dir/extracted"
+mkdir -p "$extract_dir"
+tar -xJf "$archive" -C "$extract_dir"
+
+# Its own directory, outside work_dir: it must survive past this script's exit, since
+# later steps in the job reach it through PATH, not through anything captured here.
+install_dir="$(mktemp -d)"
+cp "$extract_dir/7zz" "$install_dir/7z"
+chmod +x "$install_dir/7z"
+
+# Resolve against install_dir explicitly rather than trusting PATH order at this point in
+# the step, so a stale entry ahead of it cannot silently mask the pinned binary.
+resolved_version="$("$install_dir/7z" --help 2>&1 || true)"
+case "$resolved_version" in
+    *"${version}"*) ;;
+    *)
+        echo "expected 7-Zip ${version}, got: ${resolved_version}" >&2
+        exit 1
+        ;;
+esac
+
+echo "$install_dir" >> "$GITHUB_PATH"

--- a/apps/index/test-archive-canaries.ts
+++ b/apps/index/test-archive-canaries.ts
@@ -1,0 +1,28 @@
+// Real ModWorkshop RAR4 archives that crash Ubuntu's distro 7-Zip; the pinned build in
+// install-7zip.sh must decode them correctly. Network- and extractor-dependent, so this
+// runs on demand rather than folding into index:test, which stays offline and hermetic.
+
+import { strict as assert } from 'node:assert'
+
+import { extractMarkerEntry } from './postgres/marker-archive.js'
+
+const canaries = [
+    {
+        url: 'https://storage.modworkshop.net/mods/files/download_37_1442094920_d60fea55e86fdd548d83e4f1067764a9.rar',
+        entryName: 'Hotline Combo BLT/mod.txt',
+    },
+    {
+        url: 'https://storage.modworkshop.net/mods/files/download_575_1442103921_83d353e87af66f37297e738ad4a0dfb2.rar',
+        entryName:
+            'NPCs/units/payday2/characters/shared_textures/helmets_heavy_taser_atlas_df.texture',
+    },
+]
+
+for (const { url, entryName } of canaries) {
+    const entry = await extractMarkerEntry(url, null)
+    assert.ok(entry, `${url} must extract a marker entry`)
+    assert.equal(entry.entryName, entryName, `${url} must pick ${entryName}`)
+    assert.match(entry.sha256, /^[0-9a-f]{64}$/, `${url} must produce a sha256 digest`)
+}
+
+console.log('archive canary extraction test passed')


### PR DESCRIPTION
Ubuntu's packaged 7-Zip 23.01 reproducibly segfaults decompressing valid RAR4 archives; upstream 7-Zip 26.02 decodes the same bytes correctly with RAR5/ZIP/7z unaffected. Both Postgres workflows now provision the checksum-verified pinned binary instead of the distro package, and a canary test proves the fix through the real extraction and marker-selection path against two previously-failing ModWorkshop RAR4 archives.

## Summary

<!-- Describe what this PR changes and why. -->

## Type of change

- [ ] Application/code
- [ ] Translation
- [ ] Documentation
- [x] Other

## Translation (if applicable)

<!-- Complete this section for an existing or new language. Otherwise leave it blank. -->

- **Language:**
- **Locale code:**

See the [translation guide](https://github.com/modrexio/modrex/blob/main/TRANSLATING.md).

## Validation

- [x] Full local repository checks (`pnpm checks`)
- [ ] Relevant local checks
- [x] CI only
- [ ] Not applicable

**Details:**

<!-- List relevant commands or results. If dependencies changed, note whether licenses were regenerated. -->
