### PR TITLE
fix: Linux AppImage black window, sign-in and startup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,7 +202,8 @@ jobs:
                     libappindicator3-dev \
                     librsvg2-dev \
                     patchelf \
-                    rpm
+                    rpm \
+                    minisign
 
             - uses: pnpm/action-setup@v6
             - uses: actions/setup-node@v7
@@ -224,6 +225,69 @@ jobs:
                   TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
                   MODREX_GA_MEASUREMENT_ID: ${{ secrets.MODREX_GA_MEASUREMENT_ID }}
                   MODREX_GA_API_SECRET: ${{ secrets.MODREX_GA_API_SECRET }}
+
+            # linuxdeploy sweeps the build image's wayland libraries into the bundle as GTK
+            # dependencies, but Mesa always comes from the user's own system and cannot pair
+            # with a wayland client older than itself: against Arch's 1.26 the bundled 1.22
+            # fails EGL display creation and the window renders black. Tauri exposes no
+            # exclude list, so they come out afterwards.
+            - name: Repack AppImage without bundled wayland libraries
+              working-directory: apps/desktop/src-tauri/target/release/bundle/appimage
+              env:
+                  TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+                  TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+              run: |
+                  set -euo pipefail
+                  shopt -s nullglob
+                  APPIMAGE_FILES=(*.AppImage)
+                  if (( ${#APPIMAGE_FILES[@]} != 1 )); then
+                    echo "Expected one AppImage, found ${#APPIMAGE_FILES[@]}" >&2
+                    exit 1
+                  fi
+                  APPIMAGE=${APPIMAGE_FILES[0]}
+
+                  # Keep the runtime the bundler shipped. Left to itself appimagetool
+                  # downloads one from an unpinned continuous release, which would put a
+                  # moving binary at the head of every signed AppImage we publish.
+                  head -c "$(./"$APPIMAGE" --appimage-offset)" "$APPIMAGE" > runtime
+
+                  ./"$APPIMAGE" --appimage-extract > /dev/null
+                  rm -f squashfs-root/usr/lib/libwayland-*.so.*
+
+                  curl -fsSL -o appimagetool \
+                    https://github.com/AppImage/appimagetool/releases/download/1.9.1/appimagetool-x86_64.AppImage
+                  chmod +x appimagetool
+                  APPIMAGE_EXTRACT_AND_RUN=1 ARCH=x86_64 \
+                    ./appimagetool --runtime-file runtime squashfs-root "$APPIMAGE"
+                  rm -rf squashfs-root appimagetool runtime
+
+                  # The bundler signed the bytes this step just replaced, so without a fresh
+                  # signature every installed Linux client rejects the update.
+                  pnpm --dir "$GITHUB_WORKSPACE/apps/desktop" exec tauri signer sign "$PWD/$APPIMAGE"
+
+            - name: Verify repacked AppImage
+              working-directory: apps/desktop/src-tauri/target/release/bundle/appimage
+              run: |
+                  set -euo pipefail
+                  shopt -s nullglob
+                  APPIMAGE_FILES=(*.AppImage)
+                  APPIMAGE=${APPIMAGE_FILES[0]}
+
+                  ./"$APPIMAGE" --appimage-extract > /dev/null
+                  WAYLAND_LIBS=(squashfs-root/usr/lib/libwayland-*.so.*)
+                  rm -rf squashfs-root
+                  if (( ${#WAYLAND_LIBS[@]} != 0 )); then
+                    echo "AppImage still bundles: ${WAYLAND_LIBS[*]}" >&2
+                    exit 1
+                  fi
+
+                  # The updater accepts the release only if this passes, so it is checked
+                  # here rather than discovered by clients that can no longer update.
+                  jq -r '.plugins.updater.pubkey' \
+                    "$GITHUB_WORKSPACE/apps/desktop/src-tauri/tauri.conf.json" | base64 -d > updater.pub
+                  base64 -d < "$APPIMAGE.sig" > repacked.minisig
+                  minisign -V -m "$APPIMAGE" -p updater.pub -x repacked.minisig
+                  rm -f updater.pub repacked.minisig
 
             - uses: actions/upload-artifact@v7
               with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ All notable changes to Modrex are documented in this file. Each version's sectio
 - Fixed installed Nexus mods not recovering their details and update checks after signing in again, until the app was restarted.
 - Fixed Nexus Mods requests failing until the app was restarted when Nexus rejected a sign-in before it was due to expire.
 - Fixed oversized mod thumbnails in the Installed list view.
+- Fixed the Linux AppImage showing a black window instead of the app on systems with newer graphics drivers.
+- Fixed Modrex not starting on Linux systems that do not have xdg-utils or desktop-file-utils installed.
+- Fixed the browser, Steam and other programs opened from Modrex's Linux AppImage failing to start.
 
 ## 0.13.0
 

--- a/apps/desktop/src-tauri/src/commands/api.rs
+++ b/apps/desktop/src-tauri/src/commands/api.rs
@@ -108,6 +108,20 @@ pub(crate) fn user_agent(app: &AppHandle) -> String {
     format!("modrex/{}", app.package_info().version)
 }
 
+/// A request failure with the causes reqwest's own Display drops. On its own that
+/// Display reads "error sending request for url (...)" whether the name lookup failed,
+/// the handshake failed, or a proxy refused, and a bug report carrying only that line
+/// cannot be diagnosed.
+pub(crate) fn describe_request_error(error: &reqwest::Error) -> String {
+    let mut description = error.to_string();
+    let mut cause = std::error::Error::source(error);
+    while let Some(error) = cause {
+        description.push_str(&format!(": {error}"));
+        cause = error.source();
+    }
+    description
+}
+
 pub(crate) async fn api_get(
     app: &AppHandle,
     path: &str,
@@ -149,7 +163,7 @@ pub(crate) async fn api_get(
             .timeout(Duration::from_secs(15))
             .send()
             .await
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| describe_request_error(&e))?;
 
         if let Some(remaining) = parse_rate_limit_remaining(res.headers()) {
             RATE_REMAINING.store(remaining, Ordering::Relaxed);

--- a/apps/desktop/src-tauri/src/commands/download.rs
+++ b/apps/desktop/src-tauri/src/commands/download.rs
@@ -27,7 +27,7 @@ pub async fn download_file(
         .header("User-Agent", crate::commands::api::user_agent(app))
         .send()
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| crate::commands::api::describe_request_error(&e))?;
 
     if !res.status().is_success() {
         return Err(format!("download failed {}: {}", res.status(), url));

--- a/apps/desktop/src-tauri/src/commands/launchers/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/launchers/mod.rs
@@ -162,11 +162,15 @@ pub(super) fn open_url(url: &str) {
     // includes query strings. rundll32's FileProtocolHandler takes the URL as
     // one argument and hands it to the shell's URL handler unmodified.
     #[cfg(target_os = "windows")]
-    let _ = std::process::Command::new("rundll32")
+    let spawned = std::process::Command::new("rundll32")
         .args(["url.dll,FileProtocolHandler", url])
         .spawn();
     #[cfg(not(target_os = "windows"))]
-    let _ = std::process::Command::new("xdg-open").arg(url).spawn();
+    let spawned = std::process::Command::new("xdg-open").arg(url).spawn();
+    // A missing xdg-open otherwise looks exactly like a dead button in the UI.
+    if let Err(e) = spawned {
+        log::warn!("could not hand a url to the system opener: {e}");
+    }
 }
 
 fn open_path_on_system(path: &str) {

--- a/apps/desktop/src-tauri/src/commands/launchers/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/launchers/mod.rs
@@ -153,6 +153,19 @@ pub(super) fn run_bounded(
     }
 }
 
+/// Strips the loader overrides an AppImage run leaves in the environment. AppRun points
+/// LD_LIBRARY_PATH at the libraries inside the mounted image, and users working around
+/// graphics bugs add LD_PRELOAD on top. Anything spawned from here inherits both and loads
+/// our copies instead of its own, which is how a browser or Steam launched from Modrex
+/// fails to start at all.
+pub(crate) fn outside_bundle(cmd: &mut std::process::Command) -> &mut std::process::Command {
+    #[cfg(target_os = "linux")]
+    if std::env::var_os("APPIMAGE").is_some() || std::env::var_os("APPDIR").is_some() {
+        cmd.env_remove("LD_LIBRARY_PATH").env_remove("LD_PRELOAD");
+    }
+    cmd
+}
+
 pub(super) fn open_url(url: &str) {
     // Never route this through cmd /c start: cmd re-parses its command line,
     // so a & in a query string truncates the URL there and executes what
@@ -166,7 +179,7 @@ pub(super) fn open_url(url: &str) {
         .args(["url.dll,FileProtocolHandler", url])
         .spawn();
     #[cfg(not(target_os = "windows"))]
-    let spawned = std::process::Command::new("xdg-open").arg(url).spawn();
+    let spawned = outside_bundle(std::process::Command::new("xdg-open").arg(url)).spawn();
     // A missing xdg-open otherwise looks exactly like a dead button in the UI.
     if let Err(e) = spawned {
         log::warn!("could not hand a url to the system opener: {e}");
@@ -177,7 +190,7 @@ fn open_path_on_system(path: &str) {
     #[cfg(target_os = "windows")]
     let _ = std::process::Command::new("explorer").arg(path).spawn();
     #[cfg(not(target_os = "windows"))]
-    let _ = std::process::Command::new("xdg-open").arg(path).spawn();
+    let _ = outside_bundle(std::process::Command::new("xdg-open").arg(path)).spawn();
 }
 
 // ── Orchestration ─────────────────────────────────────────────────────────────
@@ -202,7 +215,7 @@ fn launch_with(launcher_id: &str, game: &'static GameDef, game_path: &str, opts:
         let args: Vec<&str> = opts
             .map(|o| o.split_whitespace().collect())
             .unwrap_or_default();
-        if let Err(e) = std::process::Command::new(&exe).args(&args).spawn() {
+        if let Err(e) = outside_bundle(std::process::Command::new(&exe).args(&args)).spawn() {
             log::warn!("launch_game: spawn {exe:?}: {e}");
         }
     }

--- a/apps/desktop/src-tauri/src/commands/launchers/mod_tests.rs
+++ b/apps/desktop/src-tauri/src/commands/launchers/mod_tests.rs
@@ -531,3 +531,39 @@ fn matches_process_rejects_unrelated() {
     let cmd = vec![String::from("/usr/bin/steam")];
     assert!(!matches_process("steam", &cmd, "PAYDAY3Client"));
 }
+
+// ── outside_bundle ────────────────────────────────────────────────────────
+
+// One test rather than several: it moves process-wide environment variables, and
+// parallel tests would see each other's writes.
+#[cfg(target_os = "linux")]
+#[test]
+fn outside_bundle_drops_loader_overrides_only_inside_a_bundle() {
+    fn removals(cmd: &std::process::Command) -> Vec<String> {
+        let mut keys: Vec<String> = cmd
+            .get_envs()
+            .filter(|(_, value)| value.is_none())
+            .map(|(key, _)| key.to_string_lossy().into_owned())
+            .collect();
+        keys.sort();
+        keys
+    }
+
+    std::env::remove_var("APPIMAGE");
+    std::env::remove_var("APPDIR");
+    let mut installed = std::process::Command::new("true");
+    outside_bundle(&mut installed);
+    assert!(removals(&installed).is_empty());
+
+    std::env::set_var("APPIMAGE", "/tmp/modrex_x86_64.AppImage");
+    let mut from_appimage = std::process::Command::new("true");
+    outside_bundle(&mut from_appimage);
+    std::env::remove_var("APPIMAGE");
+    assert_eq!(removals(&from_appimage), ["LD_LIBRARY_PATH", "LD_PRELOAD"]);
+
+    std::env::set_var("APPDIR", "/tmp/.mount_modrex");
+    let mut from_appdir = std::process::Command::new("true");
+    outside_bundle(&mut from_appdir);
+    std::env::remove_var("APPDIR");
+    assert_eq!(removals(&from_appdir), ["LD_LIBRARY_PATH", "LD_PRELOAD"]);
+}

--- a/apps/desktop/src-tauri/src/commands/launchers/steam.rs
+++ b/apps/desktop/src-tauri/src/commands/launchers/steam.rs
@@ -54,7 +54,9 @@ impl Launcher for Steam {
             };
             let mut args = vec!["-applaunch".to_string(), def.app_id.to_string()];
             args.extend(opts_str.split_whitespace().map(String::from));
-            if let Err(e) = std::process::Command::new(&exe).args(&args).spawn() {
+            if let Err(e) =
+                super::outside_bundle(std::process::Command::new(&exe).args(&args)).spawn()
+            {
                 log::warn!("steam launch: spawn {exe:?}: {e}");
             }
         } else {

--- a/apps/desktop/src-tauri/src/commands/mod_index.rs
+++ b/apps/desktop/src-tauri/src/commands/mod_index.rs
@@ -109,7 +109,10 @@ async fn refresh_indexes(app: &AppHandle, games: &[&str]) -> &'static str {
             return "manifest_error";
         }
         Err(error) => {
-            log::warn!("mod_index: manifest request failed: {error}");
+            log::warn!(
+                "mod_index: manifest request failed: {}",
+                crate::commands::api::describe_request_error(&error)
+            );
             return "network_error";
         }
     };
@@ -160,7 +163,7 @@ async fn refresh_game_index(
         .timeout(std::time::Duration::from_secs(300))
         .send()
         .await
-        .map_err(|error| error.to_string())?;
+        .map_err(|error| crate::commands::api::describe_request_error(&error))?;
     if !response.status().is_success() {
         return Err(format!("download returned HTTP {}", response.status()));
     }

--- a/apps/desktop/src-tauri/src/commands/mods/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/mod.rs
@@ -1949,7 +1949,10 @@ pub fn open_mods_folder(app: AppHandle, game_id: String) -> Result<(), String> {
     #[cfg(target_os = "windows")]
     let _ = std::process::Command::new("explorer").arg(&dir).spawn();
     #[cfg(target_os = "linux")]
-    let _ = std::process::Command::new("xdg-open").arg(&dir).spawn();
+    let _ = crate::commands::launchers::outside_bundle(
+        std::process::Command::new("xdg-open").arg(&dir),
+    )
+    .spawn();
     Ok(())
 }
 
@@ -1988,7 +1991,10 @@ pub fn open_mod_folder(app: AppHandle, game_id: String, tag: String) -> Result<(
     #[cfg(target_os = "windows")]
     let _ = std::process::Command::new("explorer").arg(&dir).spawn();
     #[cfg(target_os = "linux")]
-    let _ = std::process::Command::new("xdg-open").arg(&dir).spawn();
+    let _ = crate::commands::launchers::outside_bundle(
+        std::process::Command::new("xdg-open").arg(&dir),
+    )
+    .spawn();
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/src/commands/news.rs
+++ b/apps/desktop/src-tauri/src/commands/news.rs
@@ -191,7 +191,7 @@ fn curl_fetch(url: &str) -> Result<String, String> {
         use std::os::windows::process::CommandExt;
         cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
     }
-    let output = cmd
+    let output = crate::commands::launchers::outside_bundle(&mut cmd)
         .args(["-sL", "--max-time", "15", "-A", BROWSER_UA, url])
         .output()
         .map_err(|e| format!("curl unavailable: {e}"))?;

--- a/apps/desktop/src-tauri/src/commands/nexus.rs
+++ b/apps/desktop/src-tauri/src/commands/nexus.rs
@@ -107,7 +107,7 @@ async fn send_with_retry(
             .timeout(Duration::from_secs(15))
             .send()
             .await
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| crate::commands::api::describe_request_error(&e))?;
 
         if let Some(remaining) = parse_hourly_remaining(res.headers()) {
             RATE_REMAINING.store(remaining, Ordering::Relaxed);

--- a/apps/desktop/src-tauri/src/commands/nexus_oauth.rs
+++ b/apps/desktop/src-tauri/src/commands/nexus_oauth.rs
@@ -13,7 +13,7 @@ use std::sync::Mutex;
 use std::time::Duration;
 use tauri::{AppHandle, Emitter};
 
-use crate::commands::api::{http_client, user_agent};
+use crate::commands::api::{describe_request_error, http_client, user_agent};
 use crate::commands::launchers::shell_open_external;
 use crate::commands::secrets;
 use crate::commands::settings::{read_settings, update_settings, NexusOAuthTokens};
@@ -158,7 +158,7 @@ async fn token_request(
         .timeout(Duration::from_secs(15))
         .send()
         .await
-        .map_err(|e| TokenError::Transient(e.to_string()))?;
+        .map_err(|e| TokenError::Transient(describe_request_error(&e)))?;
 
     let status = res.status();
     if !status.is_success() {

--- a/apps/desktop/src-tauri/src/commands/thumbnails.rs
+++ b/apps/desktop/src-tauri/src/commands/thumbnails.rs
@@ -40,7 +40,7 @@ async fn fetch_image(app: &AppHandle, file: &str) -> Result<Vec<u8>, String> {
         )
         .send()
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| crate::commands::api::describe_request_error(&e))?;
     if !resp.status().is_success() {
         return Err(format!("status {} for {}", resp.status(), url));
     }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -183,9 +183,12 @@ pub fn run() {
             }
 
             #[cfg(desktop)]
-            {
-                app.deep_link().register("nxm")?;
-                app.deep_link().register("modrex")?;
+            for scheme in ["nxm", "modrex"] {
+                // Linux registration shells out to xdg-mime and update-desktop-database,
+                // which are not on every system. Losing deep links beats refusing to start.
+                if let Err(e) = app.deep_link().register(scheme) {
+                    log::warn!("could not register the {scheme} scheme: {e}");
+                }
             }
 
             let handle = app.handle().clone();


### PR DESCRIPTION
## Summary

Fixes the three Linux faults reported in #53.

**Black window.** `linuxdeploy` sweeps the build image's wayland libraries into the AppImage as GTK dependencies, so every Linux run pairs the user's own Mesa with our bundled wayland 1.22 from Ubuntu 24.04. Arch has been on 1.26 since 2026-08-09; against it, EGL display creation fails and the window renders black. Mesa always comes from the host, so those libraries must too. Tauri exposes no exclude list, so the release workflow now strips `libwayland-*` from the AppDir after the build, repacks, and re-signs.

The re-sign is the load-bearing part: the bundler signed the bytes the repack replaces, so without a fresh signature every installed Linux client would reject the next update. A Verify step fails the build if any wayland library survived or if the new signature does not check out against the updater pubkey, rather than letting CI publish a release that bricks auto-update.

**App not starting.** `deep_link().register()` shells out to `xdg-mime` and `update-desktop-database`. On a system without xdg-utils or desktop-file-utils it returns ENOENT, and the `?` propagated out of the setup hook and aborted the process before any window appeared. Losing deep links beats refusing to start, so it warns and continues.

**Sign-in doing nothing.** An AppImage run points `LD_LIBRARY_PATH` at the libraries inside the mounted image, and users working around graphics bugs add `LD_PRELOAD` on top. Everything Modrex spawned inherited both and loaded our copies instead of its own, which is why the browser and Steam failed to start at all. Spawns now drop both variables when running from a bundle.

Also included: request failures now carry the causes reqwest's own `Display` drops, so a report showing "error sending request for url (...)" says whether it was DNS, TLS, or a proxy.

Closes #53.

## Type of change

- [x] Application/code
- [ ] Translation
- [ ] Documentation
- [ ] Other

## Translation (if applicable)

<!-- Complete this section for an existing or new language. Otherwise leave it blank. -->

- **Language:**
- **Locale code:**

See the [translation guide](https://github.com/modrexio/modrex/blob/main/TRANSLATING.md).

## Validation

- [ ] Full local repository checks (`pnpm checks`)
- [x] Relevant local checks
- [ ] CI only
- [ ] Not applicable

**Details:**

Rust, both platforms: `cargo test` 457 passing on Linux and 459 on Windows, `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean. No frontend or dependency changes.

The startup crash was reproduced and the fix confirmed on a Linux box with no `xdg-mime`: the published 0.13.0 AppImage aborts with `PANIC: Failed to setup app ... (os error 2)`, while this branch logs two warnings, reaches `Modrex started`, and keeps running.

The repack was rehearsed end to end against the published 0.13.0 AppImage before touching the workflow:

- Repack is lossless. A file-by-file sha256 diff of the extracted bundle before and after shows exactly four files removed (the wayland libraries); the other 220 files are byte-identical, and all 30 symlinks and 50 directories are unchanged.
- The result is a valid, launchable AppImage, and the stripped bundle resolves wayland from the host, as `libgdk-3`, `libwebkit2gtk-4.1` and `libgstgl` require.
- The signature path holds: `tauri signer sign` output base64-decodes to a minisig that `minisign -V` accepts, and a one-byte tamper is rejected. The production pubkey in `tauri.conf.json` decodes to a valid minisign key.
- Both workflow steps were then run verbatim against a fixture. The success path exits 0 leaving only the AppImage and a fresh `.sig`; a surviving wayland library, a post-signing tamper, and an unexpected second AppImage in the bundle directory each fail the build as intended.
- `appimagetool` otherwise pulls its runtime from an unpinned `continuous` release at pack time, which would put a moving binary at the head of every signed AppImage, so the step reuses the runtime the bundler already shipped. Verified equivalent: only the 16-byte embedded MD5 digest differs.

Not verified here: that the black window is gone on the reporter's hardware. That needs Arch on Wayland with an RDNA4 GPU and has to come from him running a CI artifact.
