### PR TITLE
fix(desktop): carry the deep link url in the linux desktop entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Modrex are documented in this file. Each version's sectio
 
 ## Unreleased
 
+### Fixed
+
+- Fixed Nexus Mods sign-in and website mod downloads not reaching Modrex on Linux.
+
 ## 0.14.0
 
 ### Added

--- a/apps/desktop/src-tauri/linux/main.desktop
+++ b/apps/desktop/src-tauri/linux/main.desktop
@@ -1,0 +1,14 @@
+[Desktop Entry]
+Categories={{categories}}
+{{#if comment}}
+Comment={{comment}}
+{{/if}}
+Exec={{exec}} %u
+StartupWMClass={{exec}}
+Icon={{icon}}
+Name={{name}}
+Terminal=false
+Type=Application
+{{#if mime_type}}
+MimeType={{mime_type}}
+{{/if}}

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -64,10 +64,12 @@
         "linux": {
             "deb": {
                 "conflicts": ["pd3-mod-manager"],
-                "replaces": ["pd3-mod-manager"]
+                "replaces": ["pd3-mod-manager"],
+                "desktopTemplate": "linux/main.desktop"
             },
             "rpm": {
-                "obsoletes": ["pd3-mod-manager"]
+                "obsoletes": ["pd3-mod-manager"],
+                "desktopTemplate": "linux/main.desktop"
             }
         },
         "windows": {


### PR DESCRIPTION
## Summary

The desktop entry we ship claims `modrex://` and `nxm://` but has no `%u` in its `Exec` line, so the launcher drops the URL and Modrex starts with no arguments. A custom desktop template adds it, covering deb, rpm and the AppImage (whose AppDir is built from the deb tree).

Follow-up to #53. That issue is closed, but this part of it still reproduces for the reporter.

## Type of change

- [x] Application/code
- [ ] Translation
- [ ] Documentation
- [ ] Other

## Translation (if applicable)

<!-- Complete this section for an existing or new language. Otherwise leave it blank. -->

- **Language:**
- **Locale code:**

See the [translation guide](https://github.com/modrexio/modrex/blob/main/TRANSLATING.md).

## Validation

- [ ] Full local repository checks (`pnpm checks`)
- [x] Relevant local checks
- [ ] CI only
- [ ] Not applicable

**Details:**

Built a deb and an AppImage AppDir with `tauri-cli 2.11.4`: both now render `Exec=modrex %u`, differing from the 0.14.0 entry by that token alone.

Deep-linked a running app through the generated entry: `modrex://oauth/callback` and `nxm://` both arrive (`2 arg(s)`, routed to their handlers) where the current entry delivers nothing (`1 arg(s)`). A launch with no URL is unchanged.

`cargo test` 459 passing on Windows, 457 on Linux; clippy `-D warnings` and `cargo fmt --check` clean on both; prettier clean.
