### PR TITLE
Make Xbox discovery testable and stop redundant install probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to Modrex are documented in this file. Each version's sectio
 ### Changed
 
 - Startup no longer runs the Microsoft Store lookup for a game more than once at a time.
+- The game picker no longer changes which copy of a game is selected while working out which games are installed.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to Modrex are documented in this file. Each version's sectio
 
 - Added Italian as a language option for the app's interface.
 
+### Changed
+
+- Startup no longer runs the Microsoft Store lookup for a game more than once at a time.
+
 ### Fixed
 
 - Fixed Nexus Mods sign-in and website mod downloads not reaching Modrex on Linux.

--- a/apps/desktop/src-tauri/src/commands/launchers/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/launchers/mod.rs
@@ -282,6 +282,30 @@ pub async fn detected_installs(game_id: String) -> Result<Vec<DetectedInstall>, 
         .map_err(|e| e.to_string())
 }
 
+/// Which games have a copy on this machine. Read-only, unlike configure_game_path:
+/// greying out a card must not settle which copy a game uses.
+#[tauri::command]
+#[specta::specta]
+pub async fn detect_installed_games(app: AppHandle) -> Result<Vec<String>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let settings = read_settings(&app);
+        crate::commands::games::GAME_REGISTRY
+            .iter()
+            .filter(|spec| {
+                let existing = game_settings(&settings, spec.id)
+                    .cloned()
+                    .unwrap_or_default();
+                resolve_install(spec.def, spec.engine, &existing)
+                    .0
+                    .is_some()
+            })
+            .map(|spec| spec.id.to_string())
+            .collect()
+    })
+    .await
+    .map_err(|e| format!("installed-game detection failed to run: {e}"))
+}
+
 /// What re-detection has to do for a game, decided before any store is probed so that the
 /// decision itself can be reasoned about without a machine's installs in the way.
 #[derive(Debug, PartialEq)]

--- a/apps/desktop/src-tauri/src/commands/launchers/mod_tests.rs
+++ b/apps/desktop/src-tauri/src/commands/launchers/mod_tests.rs
@@ -142,7 +142,6 @@ fn is_installation_without_xbox_release_matches_executables_only() {
 
 // A Microsoft Store folder spelled differently from the game name in the registry is
 // still found, and the path handed back has to read as the folder the user sees.
-#[cfg(target_os = "windows")]
 #[test]
 fn dir_as_named_on_disk_reports_the_spelling_on_disk() {
     let dir = TempDir::new().unwrap();
@@ -153,7 +152,6 @@ fn dir_as_named_on_disk_reports_the_spelling_on_disk() {
     );
 }
 
-#[cfg(target_os = "windows")]
 #[test]
 fn dir_as_named_on_disk_falls_back_to_the_searched_name() {
     let dir = TempDir::new().unwrap();
@@ -161,6 +159,316 @@ fn dir_as_named_on_disk_falls_back_to_the_searched_name() {
         super::xbox::dir_as_named_on_disk(dir.path(), "PAYDAY 3"),
         dir.path().join("PAYDAY 3")
     );
+}
+
+// ── xbox discovery ────────────────────────────────────────────────────────
+
+use super::xbox::{find_game_in, find_via_package_manager, PackageCache, XboxEnvironment};
+use std::cell::Cell;
+use std::path::PathBuf;
+use std::time::Duration;
+
+struct FakeXboxEnv {
+    roots: Vec<PathBuf>,
+    package: Option<PathBuf>,
+    root_calls: Cell<usize>,
+    package_calls: Cell<usize>,
+}
+
+impl FakeXboxEnv {
+    fn new(roots: Vec<PathBuf>) -> Self {
+        Self {
+            roots,
+            package: None,
+            root_calls: Cell::new(0),
+            package_calls: Cell::new(0),
+        }
+    }
+
+    fn with_package(mut self, content: PathBuf) -> Self {
+        self.package = Some(content);
+        self
+    }
+}
+
+impl XboxEnvironment for FakeXboxEnv {
+    fn fixed_drive_roots(&self) -> Vec<PathBuf> {
+        self.root_calls.set(self.root_calls.get() + 1);
+        self.roots.clone()
+    }
+
+    fn package_content_path(&self, product_id: &str) -> Option<PathBuf> {
+        self.package_calls.set(self.package_calls.get() + 1);
+        if product_id != PD3.xbox.as_ref().unwrap().product_id {
+            return None;
+        }
+        self.package.clone()
+    }
+}
+
+fn xbox_exe() -> &'static str {
+    PD3.xbox.as_ref().unwrap().executable
+}
+
+fn xbox_copy(root: &Path, top: &str, game_dir: &str) -> PathBuf {
+    let content = root.join(top).join(game_dir).join("Content");
+    touch(content.join(xbox_exe()));
+    content
+}
+
+fn found(content: &Path) -> Option<String> {
+    Some(content.to_string_lossy().into_owned())
+}
+
+#[test]
+fn finds_install_in_the_standard_top_level_dir() {
+    let dir = TempDir::new().unwrap();
+    let content = xbox_copy(dir.path(), "XboxGames", PD3.name);
+    let env = FakeXboxEnv::new(vec![dir.path().to_path_buf()]);
+    assert_eq!(find_game_in(&env, &PD3), found(&content));
+}
+
+#[test]
+fn finds_install_in_a_nonstandard_top_level_dir() {
+    let dir = TempDir::new().unwrap();
+    let content = xbox_copy(dir.path(), "Games", PD3.name);
+    let env = FakeXboxEnv::new(vec![dir.path().to_path_buf()]);
+    assert_eq!(find_game_in(&env, &PD3), found(&content));
+}
+
+#[test]
+fn finds_install_on_a_later_root() {
+    let first = TempDir::new().unwrap();
+    let second = TempDir::new().unwrap();
+    std::fs::create_dir(first.path().join("Windows")).unwrap();
+    let content = xbox_copy(second.path(), "XboxGames", PD3.name);
+    let env = FakeXboxEnv::new(vec![
+        first.path().to_path_buf(),
+        second.path().to_path_buf(),
+    ]);
+    assert_eq!(find_game_in(&env, &PD3), found(&content));
+}
+
+#[test]
+fn unreadable_root_is_skipped_and_the_rest_are_searched() {
+    let dir = TempDir::new().unwrap();
+    let content = xbox_copy(dir.path(), "XboxGames", PD3.name);
+    let env = FakeXboxEnv::new(vec![
+        dir.path().join("no-such-root"),
+        dir.path().to_path_buf(),
+    ]);
+    assert_eq!(find_game_in(&env, &PD3), found(&content));
+}
+
+#[test]
+fn a_root_outside_the_reported_set_is_never_searched() {
+    let listed = TempDir::new().unwrap();
+    let unlisted = TempDir::new().unwrap();
+    xbox_copy(unlisted.path(), "XboxGames", PD3.name);
+    let env = FakeXboxEnv::new(vec![listed.path().to_path_buf()]);
+    assert_eq!(find_game_in(&env, &PD3), None);
+}
+
+#[test]
+fn a_top_level_file_is_not_treated_as_a_directory() {
+    let dir = TempDir::new().unwrap();
+    touch(dir.path().join("XboxGames"));
+    let env = FakeXboxEnv::new(vec![dir.path().to_path_buf()]);
+    assert_eq!(find_game_in(&env, &PD3), None);
+}
+
+#[test]
+fn a_deep_install_is_found_via_the_package_manager() {
+    let dir = TempDir::new().unwrap();
+    let content = dir
+        .path()
+        .join("Deep")
+        .join("Nested")
+        .join(PD3.name)
+        .join("Content");
+    touch(content.join(xbox_exe()));
+    let env = FakeXboxEnv::new(vec![dir.path().to_path_buf()]).with_package(content.clone());
+    assert_eq!(find_game_in(&env, &PD3), found(&content));
+}
+
+#[test]
+fn a_drive_hit_stops_before_the_package_manager() {
+    let dir = TempDir::new().unwrap();
+    let content = xbox_copy(dir.path(), "XboxGames", PD3.name);
+    let elsewhere = xbox_copy(dir.path(), "Other", "Something Else");
+    let env = FakeXboxEnv::new(vec![dir.path().to_path_buf()]).with_package(elsewhere);
+    assert_eq!(find_game_in(&env, &PD3), found(&content));
+    assert_eq!(env.package_calls.get(), 0);
+}
+
+#[test]
+fn a_package_for_another_product_id_is_not_matched() {
+    let dir = TempDir::new().unwrap();
+    let content = dir.path().join("Deep").join(PD3.name).join("Content");
+    touch(content.join(xbox_exe()));
+    let env = FakeXboxEnv::new(vec![]).with_package(content);
+    assert_eq!(find_via_package_manager(&env, "NOTPD3", xbox_exe()), None);
+}
+
+#[test]
+fn a_package_without_the_executable_is_rejected() {
+    let dir = TempDir::new().unwrap();
+    let content = dir.path().join("Deep").join(PD3.name).join("Content");
+    std::fs::create_dir_all(&content).unwrap();
+    let env = FakeXboxEnv::new(vec![]).with_package(content);
+    assert_eq!(find_game_in(&env, &PD3), None);
+}
+
+#[test]
+fn a_package_pointing_at_a_gone_location_is_rejected() {
+    let dir = TempDir::new().unwrap();
+    let env = FakeXboxEnv::new(vec![]).with_package(dir.path().join("gone").join("Content"));
+    assert_eq!(find_game_in(&env, &PD3), None);
+}
+
+#[test]
+fn a_package_query_that_answers_nothing_yields_none() {
+    let dir = TempDir::new().unwrap();
+    let env = FakeXboxEnv::new(vec![dir.path().to_path_buf()]);
+    assert_eq!(find_game_in(&env, &PD3), None);
+}
+
+#[test]
+fn a_game_without_a_store_build_asks_the_machine_nothing() {
+    let dir = TempDir::new().unwrap();
+    let env = FakeXboxEnv::new(vec![dir.path().to_path_buf()]);
+    assert_eq!(find_game_in(&env, &PD2), None);
+    assert_eq!(env.root_calls.get(), 0);
+    assert_eq!(env.package_calls.get(), 0);
+}
+
+#[test]
+fn each_call_requeries_the_environment() {
+    let dir = TempDir::new().unwrap();
+    let env = FakeXboxEnv::new(vec![dir.path().to_path_buf()]);
+    for _ in 0..3 {
+        assert_eq!(find_game_in(&env, &PD3), None);
+    }
+    assert_eq!(env.root_calls.get(), 3);
+    assert_eq!(env.package_calls.get(), 3);
+}
+
+// ── package cache ─────────────────────────────────────────────────────────
+
+#[test]
+fn probes_landing_together_query_the_package_manager_once() {
+    let dir = TempDir::new().unwrap();
+    // Two levels down, so the drive scan misses and the package manager is reached.
+    let content = dir
+        .path()
+        .join("Deep")
+        .join("Nested")
+        .join(PD3.name)
+        .join("Content");
+    touch(content.join(xbox_exe()));
+    let env = PackageCache::new(
+        FakeXboxEnv::new(vec![dir.path().to_path_buf()]).with_package(content.clone()),
+        Duration::MAX,
+    );
+    for _ in 0..3 {
+        assert_eq!(find_game_in(&env, &PD3), found(&content));
+    }
+    assert_eq!(env.inner.package_calls.get(), 1);
+}
+
+#[test]
+fn a_held_path_is_still_checked_on_disk() {
+    let dir = TempDir::new().unwrap();
+    let content = dir
+        .path()
+        .join("Deep")
+        .join("Nested")
+        .join(PD3.name)
+        .join("Content");
+    let exe = content.join(xbox_exe());
+    touch(exe.clone());
+    let env = PackageCache::new(
+        FakeXboxEnv::new(vec![dir.path().to_path_buf()]).with_package(content.clone()),
+        Duration::MAX,
+    );
+    assert_eq!(find_game_in(&env, &PD3), found(&content));
+
+    std::fs::remove_file(&exe).unwrap();
+    assert_eq!(find_game_in(&env, &PD3), None);
+    assert_eq!(env.inner.package_calls.get(), 1);
+}
+
+#[test]
+fn a_negative_answer_is_held_as_well() {
+    let dir = TempDir::new().unwrap();
+    let env = PackageCache::new(
+        FakeXboxEnv::new(vec![dir.path().to_path_buf()]),
+        Duration::MAX,
+    );
+    for _ in 0..3 {
+        assert_eq!(find_game_in(&env, &PD3), None);
+    }
+    assert_eq!(env.inner.package_calls.get(), 1);
+}
+
+#[test]
+fn an_expired_answer_is_asked_again() {
+    let dir = TempDir::new().unwrap();
+    let env = PackageCache::new(
+        FakeXboxEnv::new(vec![dir.path().to_path_buf()]),
+        Duration::ZERO,
+    );
+    for _ in 0..3 {
+        assert_eq!(find_game_in(&env, &PD3), None);
+    }
+    assert_eq!(env.inner.package_calls.get(), 3);
+}
+
+#[test]
+fn each_product_id_is_held_separately() {
+    let env = PackageCache::new(FakeXboxEnv::new(vec![]), Duration::MAX);
+    assert_eq!(find_via_package_manager(&env, "ONE", xbox_exe()), None);
+    assert_eq!(find_via_package_manager(&env, "TWO", xbox_exe()), None);
+    assert_eq!(env.inner.package_calls.get(), 2);
+}
+
+#[test]
+fn drive_roots_are_asked_for_every_time() {
+    let dir = TempDir::new().unwrap();
+    let env = PackageCache::new(
+        FakeXboxEnv::new(vec![dir.path().to_path_buf()]),
+        Duration::MAX,
+    );
+    for _ in 0..3 {
+        assert_eq!(find_game_in(&env, &PD3), None);
+    }
+    assert_eq!(env.inner.root_calls.get(), 3);
+}
+
+// The drive scan reaches dir_as_named_on_disk only on a case-insensitive filesystem.
+#[cfg(target_os = "windows")]
+#[test]
+fn a_differently_cased_folder_is_returned_as_it_is_spelled() {
+    let dir = TempDir::new().unwrap();
+    let content = xbox_copy(dir.path(), "XboxGames", "Payday 3");
+    let env = FakeXboxEnv::new(vec![dir.path().to_path_buf()]);
+    assert_eq!(find_game_in(&env, &PD3), found(&content));
+}
+
+// The package query is left out because it spawns PowerShell for up to 15 seconds.
+#[cfg(target_os = "windows")]
+#[test]
+fn the_real_environment_reports_the_system_drive() {
+    let roots = super::xbox::WindowsEnvironment.fixed_drive_roots();
+    assert!(roots.contains(&PathBuf::from("C:\\")), "got {roots:?}");
+}
+
+#[cfg(not(target_os = "windows"))]
+#[test]
+fn the_launcher_finds_nothing_off_windows() {
+    use super::types::Launcher;
+    assert_eq!(super::xbox::Xbox.find_game(&PD3), None);
+    assert!(!super::xbox::Xbox.is_installed());
 }
 
 // ── resolve_install ───────────────────────────────────────────────────────

--- a/apps/desktop/src-tauri/src/commands/launchers/xbox.rs
+++ b/apps/desktop/src-tauri/src/commands/launchers/xbox.rs
@@ -1,12 +1,19 @@
 use crate::commands::launchers::types::{GameDef, Launcher};
-#[cfg(target_os = "windows")]
-use std::fs;
 use std::path::Path;
-#[cfg(target_os = "windows")]
+
+#[cfg(any(target_os = "windows", test))]
+use std::collections::HashMap;
+#[cfg(any(target_os = "windows", test))]
+use std::fs;
+#[cfg(any(target_os = "windows", test))]
 use std::path::PathBuf;
 
 #[cfg(target_os = "windows")]
 const GAMING_APP: &str = "Microsoft.GamingApp_8wekyb3d8bbwe";
+
+// Long enough to cover the startup burst, far short of any Store install.
+#[cfg(target_os = "windows")]
+const PACKAGE_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(30);
 
 pub struct Xbox;
 
@@ -28,9 +35,10 @@ impl Launcher for Xbox {
 
     #[cfg(target_os = "windows")]
     fn find_game(&self, game: &GameDef) -> Option<String> {
-        let def = game.xbox.as_ref()?;
-        find_in_drives(game.name, def.executable)
-            .or_else(|| find_via_package_manager(def.product_id, def.executable))
+        static ENV: std::sync::OnceLock<PackageCache<WindowsEnvironment>> =
+            std::sync::OnceLock::new();
+        let env = ENV.get_or_init(|| PackageCache::new(WindowsEnvironment, PACKAGE_CACHE_TTL));
+        find_game_in(env, game)
     }
 
     #[cfg(not(target_os = "windows"))]
@@ -54,34 +62,117 @@ impl Launcher for Xbox {
     }
 }
 
-// Neither call does volume or network I/O, so enumeration can't stall on a dead
-// drive. Non-fixed drives are excluded: stats on a disconnected network/VPN drive
-// block for the SMB timeout, and Xbox installs only ever live on fixed volumes.
-#[cfg(target_os = "windows")]
-fn fixed_drive_roots() -> Vec<PathBuf> {
-    const DRIVE_FIXED: u32 = 3;
-    #[link(name = "kernel32")]
-    extern "system" {
-        fn GetLogicalDrives() -> u32;
-        fn GetDriveTypeW(root_path_name: *const u16) -> u32;
+#[cfg(any(target_os = "windows", test))]
+pub(super) trait XboxEnvironment {
+    fn fixed_drive_roots(&self) -> Vec<PathBuf>;
+
+    fn package_content_path(&self, product_id: &str) -> Option<PathBuf>;
+}
+
+#[cfg(any(target_os = "windows", test))]
+pub(super) struct PackageCache<E> {
+    pub(super) inner: E,
+    ttl: std::time::Duration,
+    answers: std::sync::Mutex<HashMap<String, (std::time::Instant, Option<PathBuf>)>>,
+}
+
+#[cfg(any(target_os = "windows", test))]
+impl<E> PackageCache<E> {
+    pub(super) fn new(inner: E, ttl: std::time::Duration) -> Self {
+        Self {
+            inner,
+            ttl,
+            answers: std::sync::Mutex::new(HashMap::new()),
+        }
     }
-    let mask = unsafe { GetLogicalDrives() };
-    (0..26)
-        .filter(|i| mask & (1u32 << i) != 0)
-        .map(|i| format!("{}:\\", (b'A' + i) as char))
-        .filter(|root| {
-            let wide: Vec<u16> = root.encode_utf16().chain(std::iter::once(0)).collect();
-            unsafe { GetDriveTypeW(wide.as_ptr()) == DRIVE_FIXED }
-        })
-        .map(PathBuf::from)
-        .collect()
+}
+
+#[cfg(any(target_os = "windows", test))]
+impl<E: XboxEnvironment> XboxEnvironment for PackageCache<E> {
+    fn fixed_drive_roots(&self) -> Vec<PathBuf> {
+        self.inner.fixed_drive_roots()
+    }
+
+    // The lock is held across the query so a probe arriving during one waits for its
+    // answer instead of spawning a second PowerShell.
+    fn package_content_path(&self, product_id: &str) -> Option<PathBuf> {
+        let mut answers = self.answers.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some((asked, path)) = answers.get(product_id) {
+            if asked.elapsed() < self.ttl {
+                return path.clone();
+            }
+        }
+        let path = self.inner.package_content_path(product_id);
+        answers.insert(
+            product_id.to_string(),
+            (std::time::Instant::now(), path.clone()),
+        );
+        path
+    }
+}
+
+#[cfg(any(target_os = "windows", test))]
+pub(super) fn find_game_in(env: &dyn XboxEnvironment, game: &GameDef) -> Option<String> {
+    let def = game.xbox.as_ref()?;
+    find_in_drives(env, game.name, def.executable)
+        .or_else(|| find_via_package_manager(env, def.product_id, def.executable))
+}
+
+#[cfg(target_os = "windows")]
+pub(super) struct WindowsEnvironment;
+
+#[cfg(target_os = "windows")]
+impl XboxEnvironment for WindowsEnvironment {
+    // Neither call does volume or network I/O, so enumeration can't stall on a dead
+    // drive. Non-fixed drives are excluded: stats on a disconnected network/VPN drive
+    // block for the SMB timeout, and Xbox installs only ever live on fixed volumes.
+    fn fixed_drive_roots(&self) -> Vec<PathBuf> {
+        const DRIVE_FIXED: u32 = 3;
+        #[link(name = "kernel32")]
+        extern "system" {
+            fn GetLogicalDrives() -> u32;
+            fn GetDriveTypeW(root_path_name: *const u16) -> u32;
+        }
+        let mask = unsafe { GetLogicalDrives() };
+        (0..26)
+            .filter(|i| mask & (1u32 << i) != 0)
+            .map(|i| format!("{}:\\", (b'A' + i) as char))
+            .filter(|root| {
+                let wide: Vec<u16> = root.encode_utf16().chain(std::iter::once(0)).collect();
+                unsafe { GetDriveTypeW(wide.as_ptr()) == DRIVE_FIXED }
+            })
+            .map(PathBuf::from)
+            .collect()
+    }
+
+    // The filter stays in the script because run_bounded reads stdout only after exit:
+    // returning every install path instead of one line could fill the pipe and deadlock.
+    fn package_content_path(&self, product_id: &str) -> Option<PathBuf> {
+        let script = format!(
+            "$p=Get-AppxPackage|?{{$c=Join-Path $_.InstallLocation 'Content\\MicrosoftGame.config';(Test-Path $c)-and((gc $c -Raw)-match '{}')}}|Select -First 1;if($p){{Join-Path $p.InstallLocation 'Content'}}",
+            product_id
+        );
+        let mut cmd = std::process::Command::new("powershell");
+        cmd.args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-WindowStyle",
+            "Hidden",
+            "-Command",
+            &script,
+        ]);
+        // Get-AppxPackage legitimately takes ~10s on slow machines, bound generously.
+        let out = super::run_bounded(cmd, std::time::Duration::from_secs(15))?;
+        let path = out.trim();
+        (!path.is_empty()).then(|| PathBuf::from(path))
+    }
 }
 
 // Windows compares paths case-insensitively, so a folder is found whatever its real
 // spelling is and the name the search was built from is what ends up saved and shown.
 // Reading the name back off disk is what makes the stored path match the user's folder.
 // Runs only once a game has been found, so the scan itself costs no extra directory reads.
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", test))]
 pub(super) fn dir_as_named_on_disk(parent: &Path, name: &str) -> PathBuf {
     fs::read_dir(parent)
         .ok()
@@ -94,9 +185,13 @@ pub(super) fn dir_as_named_on_disk(parent: &Path, name: &str) -> PathBuf {
         .unwrap_or_else(|| parent.join(name))
 }
 
-#[cfg(target_os = "windows")]
-fn find_in_drives(game_name: &str, xbox_executable: &str) -> Option<String> {
-    for drive_root in fixed_drive_roots() {
+#[cfg(any(target_os = "windows", test))]
+pub(super) fn find_in_drives(
+    env: &dyn XboxEnvironment,
+    game_name: &str,
+    xbox_executable: &str,
+) -> Option<String> {
+    for drive_root in env.fixed_drive_roots() {
         let dirs = match fs::read_dir(&drive_root) {
             Ok(d) => d,
             Err(_) => continue,
@@ -115,29 +210,14 @@ fn find_in_drives(game_name: &str, xbox_executable: &str) -> Option<String> {
     None
 }
 
-#[cfg(target_os = "windows")]
-fn find_via_package_manager(product_id: &str, xbox_executable: &str) -> Option<String> {
-    let script = format!(
-        "$p=Get-AppxPackage|?{{$c=Join-Path $_.InstallLocation 'Content\\MicrosoftGame.config';(Test-Path $c)-and((gc $c -Raw)-match '{}')}}|Select -First 1;if($p){{Join-Path $p.InstallLocation 'Content'}}",
-        product_id
-    );
-    let mut cmd = std::process::Command::new("powershell");
-    cmd.args([
-        "-NoProfile",
-        "-NonInteractive",
-        "-WindowStyle",
-        "Hidden",
-        "-Command",
-        &script,
-    ]);
-    // Get-AppxPackage legitimately takes ~10s on slow machines, bound generously.
-    let out = super::run_bounded(cmd, std::time::Duration::from_secs(15))?;
-    let path = out.trim().to_string();
-    if path.is_empty() {
-        return None;
-    }
-    Path::new(&path)
-        .join(xbox_executable)
+#[cfg(any(target_os = "windows", test))]
+pub(super) fn find_via_package_manager(
+    env: &dyn XboxEnvironment,
+    product_id: &str,
+    xbox_executable: &str,
+) -> Option<String> {
+    let path = env.package_content_path(product_id)?;
+    path.join(xbox_executable)
         .exists()
-        .then_some(path)
+        .then(|| path.to_string_lossy().into_owned())
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -90,6 +90,7 @@ fn ipc_builder() -> tauri_specta::Builder<tauri::Wry> {
             commands::loaders::install_loader,
             // launchers & system
             commands::launchers::detected_installs,
+            commands::launchers::detect_installed_games,
             commands::launchers::configure_game_path,
             commands::launchers::select_game_install,
             commands::launchers::pick_folder,

--- a/apps/desktop/src/renderer/src/api.ts
+++ b/apps/desktop/src/renderer/src/api.ts
@@ -548,6 +548,9 @@ export const api = {
     getDetectedInstalls(gameId: string): Promise<DetectedInstall[]> {
         return commands.detectedInstalls(gameId)
     },
+    detectInstalledGames(): Promise<string[]> {
+        return commands.detectInstalledGames()
+    },
     openExternal(url: string): Promise<void> {
         return commands.shellOpenExternal(url)
     },

--- a/apps/desktop/src/renderer/src/components/WelcomeScreen.tsx
+++ b/apps/desktop/src/renderer/src/components/WelcomeScreen.tsx
@@ -52,11 +52,14 @@ export function WelcomeScreen({ onSelectGame }: Props) {
                     g in prev ? prev : { ...prev, [g]: gs.gamePath != null }
                 )
             })
-            void api.findGamePath(g).then((path) => {
-                if (cancelled) return
-                setInstalledStatus((prev) => ({ ...prev, [g]: path !== null }))
-            })
         }
+        void api.detectInstalledGames().then((installed) => {
+            if (cancelled) return
+            const found = new Set(installed)
+            setInstalledStatus(
+                Object.fromEntries((Object.keys(GAMES) as GameId[]).map((g) => [g, found.has(g)]))
+            )
+        })
         return () => {
             cancelled = true
         }

--- a/apps/desktop/src/shared/bindings.ts
+++ b/apps/desktop/src/shared/bindings.ts
@@ -130,6 +130,11 @@ export const commands = {
 	checkLoader: (loaderId: string, gameId: string, gamePath: string) => __TAURI_INVOKE<boolean>("check_loader", { loaderId, gameId, gamePath }),
 	installLoader: (loaderId: string, gamePath: string) => __TAURI_INVOKE<null>("install_loader", { loaderId, gamePath }),
 	detectedInstalls: (gameId: string) => __TAURI_INVOKE<DetectedInstall[]>("detected_installs", { gameId }),
+	/**
+	 *  Which games have a copy on this machine. Read-only, unlike configure_game_path:
+	 *  greying out a card must not settle which copy a game uses.
+	 */
+	detectInstalledGames: () => __TAURI_INVOKE<string[]>("detect_installed_games"),
 	configureGamePath: (gameId: string, gamePath: string | null) => __TAURI_INVOKE<null>("configure_game_path", { gameId, gamePath }),
 	/**
 	 *  Points a game at one specific store's copy, moving the game path and the launcher


### PR DESCRIPTION
## Summary

Makes Xbox / Microsoft Store installation discovery testable, and stops the two places that probe for installs from doing redundant work.

**Xbox discovery is now reachable from CI.** Every function behind it (`find_in_drives`, `find_via_package_manager`, `fixed_drive_roots`, `dir_as_named_on_disk`) was `#[cfg(target_os = "windows")]`, and CI runs on `ubuntu-latest` — so none of it was ever compiled or tested, including the two existing `dir_as_named_on_disk` tests. An `XboxEnvironment` trait now isolates the two questions that need the OS (fixed drive roots, and the package manager lookup); the search itself is ordinary `std::fs` and compiles everywhere, with 22 tests running against a fake. Only `WindowsEnvironment` stays Windows-only.

The PowerShell script is unchanged, deliberately. Moving the `product_id` filter out of the script and into Rust would have changed two things at once: `run_bounded` reads stdout only after the child exits, so returning every install path instead of one line could fill the pipe and deadlock; and a raw-text regex match is not the same test as a parsed field. Both were left alone.

**Startup no longer runs the Microsoft Store lookup twice.** `configure_game_path` and `detected_installs` fire milliseconds apart on startup and both reach Xbox discovery, so each spawned its own `Get-AppxPackage` (~10s). A 30-second window holds the last answer — far shorter than any Store install, so a game installed while Modrex runs is still found. Only the query is held, not the verdict: the executable is still checked on disk every time, so an uninstalled copy stops being reported inside the window. Drive roots are deliberately not held; they cost microseconds.

**The game picker no longer settles which copy of a game you use.** It called `findGamePath` per game purely to grey out cards — but that is `configure_game_path`, which persists its result, so opening the picker wrote `settings.json` five times and could pin an unpinned game to whichever store won the probe order. Two stores' copies share no files, so that decision belongs to the user, not to a filter checkbox. A new read-only `detect_installed_games` answers for every game in one pass.

No behaviour change on Windows for the seam itself: layer order, the executable re-check, casing recovery, fixed-drive filtering, the Gaming App gate, and every failure-to-`None` path are unchanged code.

## Type of change

- [x] Application/code
- [ ] Translation
- [ ] Documentation
- [ ] Other

## Translation (if applicable)

- **Language:**
- **Locale code:**

## Validation

- [x] Full local repository checks (`pnpm checks`)
- [x] Relevant local checks

**Details:**

Rust gates run on **both** Windows and Linux (WSL Ubuntu, `webkit2gtk-4.1`), since the point of the change is that this code now compiles off Windows:

| | Windows | Linux |
| --- | --- | --- |
| `cargo clippy --all-targets -- -D warnings` | clean | clean |
| `cargo clippy -- -D warnings` (release cfg, proves no dead code) | clean | clean |
| `cargo test` | 481 pass | 480 pass |

Also `cargo fmt --check`, `typecheck`, `lint`, `format:check`, `test:renderer` (280 tests / 17 files), regenerated `bindings.ts`, and `check-version`, `check-commands` (86 commands), `check-csp`, `check-games`, `check-sources`, `check-updater`, `check-i18n`.

Verified against a real Microsoft Store install of PAYDAY 3:

- Xbox discovery still resolves it — `found PAYDAY 3 via xbox: C:\XboxGames\PAYDAY 3\Content`.
- Before: every probe line appeared twice per startup. After: once per game, in a single pass.
- Opening the picker probes only unsettled games; `pd3`/`pd2`/`cb` hit the `Keep` branch and are not probed at all.

No dependency changes, so `THIRD_PARTY_LICENSES.md` was not regenerated.
