### PR TITLE
fix(desktop): make mod state transitions failure-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,13 +25,9 @@ All notable changes to Modrex are documented in this file. Each version's sectio
 - Opening the log from Settings now opens the log file itself instead of writing a copy to a predictable name in the system temporary folder, which another program could have redirected at one of your own files.
 - Fixed cleanup after installing a .pdmod file or a loose non-archive file being able to target the system temporary folder instead of only the files Modrex had staged there.
 - Fixed Nexus Mods sign-in and website mod downloads not reaching Modrex on Linux.
-- Enabling or disabling a mod that could not be moved, for example while the game is running or a file is locked, now reports the failure instead of showing the mod as changed while the game still loads it as before.
-- Enabling or disabling a mod whose files are no longer on disk now reports that, instead of only changing the mod's recorded state.
+- Enabling or disabling a mod now reports when it did not work, whether the file is locked, its files are no longer on disk, or one mod fails inside a folder or multi-select action, instead of showing the mod as changed while the game still loads it as before.
 - A pak and its accompanying .ucas and .utoc files are now moved and copied as one; if any of them cannot be moved, the mod is put back rather than left split between folders.
 - Modrex no longer rebuilds its mod list over a mod list it could not read. Your mods are still listed, folders and load order are left untouched, and a notice explains why nothing is being saved.
-- Enabling or disabling several mods at once now tries all of them and reports which ones failed, instead of stopping silently at the first problem.
-- Fixed a mod or folder being left spinning, and unusable until restart, when the installed list could not be reloaded after enabling or disabling it.
-- Fixed a Crime Boss mod being switched on or off in the game itself when Modrex refused the change, such as when a copy of the mod sits in both the active and disabled folders.
 
 ## 0.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to Modrex are documented in this file. Each version's sectio
 - Modrex no longer rebuilds its mod list over a mod list it could not read. Your mods are still listed, folders and load order are left untouched, and a notice explains why nothing is being saved.
 - Enabling or disabling several mods at once now tries all of them and reports which ones failed, instead of stopping silently at the first problem.
 - Fixed a mod or folder being left spinning, and unusable until restart, when the installed list could not be reloaded after enabling or disabling it.
+- Fixed a Crime Boss mod being switched on or off in the game itself when Modrex refused the change, such as when a copy of the mod sits in both the active and disabled folders.
 
 ## 0.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,9 @@ All notable changes to Modrex are documented in this file. Each version's sectio
 - Opening the log from Settings now opens the log file itself instead of writing a copy to a predictable name in the system temporary folder, which another program could have redirected at one of your own files.
 - Fixed cleanup after installing a .pdmod file or a loose non-archive file being able to target the system temporary folder instead of only the files Modrex had staged there.
 - Fixed Nexus Mods sign-in and website mod downloads not reaching Modrex on Linux.
-- Enabling or disabling a mod now reports when it did not work, whether the file is locked, its files are no longer on disk, or one mod fails inside a folder or multi-select action, instead of showing the mod as changed while the game still loads it as before.
-- A pak and its accompanying .ucas and .utoc files are now moved and copied as one; if any of them cannot be moved, the mod is put back rather than left split between folders.
-- Modrex no longer rebuilds its mod list over a mod list it could not read. Your mods are still listed, folders and load order are left untouched, and a notice explains why nothing is being saved.
+- Fixed enabling or disabling a mod being reported as done when its files could not be moved, such as while the game is running.
+- Fixed a mod being left split between folders when its .ucas or .utoc file could not be moved with its pak.
+- Fixed Modrex rebuilding its mod list over a mod list it could not read, which lost folders and load order.
 
 ## 0.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ All notable changes to Modrex are documented in this file. Each version's sectio
 - Opening the log from Settings now opens the log file itself instead of writing a copy to a predictable name in the system temporary folder, which another program could have redirected at one of your own files.
 - Fixed cleanup after installing a .pdmod file or a loose non-archive file being able to target the system temporary folder instead of only the files Modrex had staged there.
 - Fixed Nexus Mods sign-in and website mod downloads not reaching Modrex on Linux.
+- Enabling or disabling a mod that could not be moved, for example while the game is running or a file is locked, now reports the failure instead of showing the mod as changed while the game still loads it as before.
+- A pak and its accompanying .ucas and .utoc files are now moved and copied as one; if any of them cannot be moved, the mod is put back rather than left split between folders.
+- Modrex no longer rebuilds its mod list over a mod list it could not read. Your mods are still listed, folders and load order are left untouched, and a notice explains why nothing is being saved.
+- Enabling or disabling several mods at once now tries all of them and reports which ones failed, instead of stopping silently at the first problem.
 
 ## 0.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ All notable changes to Modrex are documented in this file. Each version's sectio
 - Fixed Nexus Mods sign-in and website mod downloads not reaching Modrex on Linux.
 - Fixed enabling or disabling a mod being reported as done when its files could not be moved, such as while the game is running.
 - Fixed a mod being left split between folders when its .ucas or .utoc file could not be moved with its pak.
-- Fixed Modrex rebuilding its mod list over a mod list it could not read, which lost folders and load order.
+- Fixed mod folders and load order being lost when Modrex could not read its saved mod list.
 
 ## 0.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to Modrex are documented in this file. Each version's sectio
 - A pak and its accompanying .ucas and .utoc files are now moved and copied as one; if any of them cannot be moved, the mod is put back rather than left split between folders.
 - Modrex no longer rebuilds its mod list over a mod list it could not read. Your mods are still listed, folders and load order are left untouched, and a notice explains why nothing is being saved.
 - Enabling or disabling several mods at once now tries all of them and reports which ones failed, instead of stopping silently at the first problem.
+- Fixed a mod or folder being left spinning, and unusable until restart, when the installed list could not be reloaded after enabling or disabling it.
 
 ## 0.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to Modrex are documented in this file. Each version's sectio
 - Fixed cleanup after installing a .pdmod file or a loose non-archive file being able to target the system temporary folder instead of only the files Modrex had staged there.
 - Fixed Nexus Mods sign-in and website mod downloads not reaching Modrex on Linux.
 - Enabling or disabling a mod that could not be moved, for example while the game is running or a file is locked, now reports the failure instead of showing the mod as changed while the game still loads it as before.
+- Enabling or disabling a mod whose files are no longer on disk now reports that, instead of only changing the mod's recorded state.
 - A pak and its accompanying .ucas and .utoc files are now moved and copied as one; if any of them cannot be moved, the mod is put back rather than left split between folders.
 - Modrex no longer rebuilds its mod list over a mod list it could not read. Your mods are still listed, folders and load order are left untouched, and a notice explains why nothing is being saved.
 - Enabling or disabling several mods at once now tries all of them and reports which ones failed, instead of stopping silently at the first problem.

--- a/README.md
+++ b/README.md
@@ -150,12 +150,12 @@ back to English in the app.
 <!-- prettier-ignore -->
 | Language | Translation | Contributors |
 | --- | --- | --- |
-| [English (en)](apps/desktop/src/renderer/src/i18n/en.json) | <img src="assets/i18n/status/en.svg" alt="English source: 459 valid strings."> Complete | - |
-| [Deutsch (de)](apps/desktop/src/renderer/src/i18n/de.json) | <img src="assets/i18n/status/de.svg" alt="Deutsch (de): 456 accepted, 0 review, 3 missing; 99.3%."> 99.3% | [TarekLP](https://github.com/TarekLP) |
-| [Italiano (it)](apps/desktop/src/renderer/src/i18n/it.json) | <img src="assets/i18n/status/it.svg" alt="Italiano (it): 424 accepted, 0 review, 35 missing; 92.4%."> 92.4% | [Enderbox89](https://github.com/Enderbox89) |
-| [Русский (ru)](apps/desktop/src/renderer/src/i18n/ru.json) | <img src="assets/i18n/status/ru.svg" alt="Русский (ru): 424 accepted, 0 review, 35 missing; 92.4%."> 92.4% | [ShulhaOleh](https://github.com/ShulhaOleh) |
-| [Українська (uk)](apps/desktop/src/renderer/src/i18n/uk.json) | <img src="assets/i18n/status/uk.svg" alt="Українська (uk): 424 accepted, 0 review, 35 missing; 92.4%."> 92.4% | [ShevRuslan1](https://github.com/ShevRuslan1) |
-| [中文（中国） (zh-CN)](apps/desktop/src/renderer/src/i18n/zh-CN.json) | <img src="assets/i18n/status/zh-CN.svg" alt="中文（中国） (zh-CN): 456 accepted, 0 review, 3 missing; 99.3%."> 99.3% | [illianezheviasov](https://github.com/illianezheviasov) |
+| [English (en)](apps/desktop/src/renderer/src/i18n/en.json) | <img src="assets/i18n/status/en.svg" alt="English source: 460 valid strings."> Complete | - |
+| [Deutsch (de)](apps/desktop/src/renderer/src/i18n/de.json) | <img src="assets/i18n/status/de.svg" alt="Deutsch (de): 456 accepted, 0 review, 4 missing; 99.1%."> 99.1% | [TarekLP](https://github.com/TarekLP) |
+| [Italiano (it)](apps/desktop/src/renderer/src/i18n/it.json) | <img src="assets/i18n/status/it.svg" alt="Italiano (it): 424 accepted, 0 review, 36 missing; 92.2%."> 92.2% | [Enderbox89](https://github.com/Enderbox89) |
+| [Русский (ru)](apps/desktop/src/renderer/src/i18n/ru.json) | <img src="assets/i18n/status/ru.svg" alt="Русский (ru): 424 accepted, 0 review, 36 missing; 92.2%."> 92.2% | [ShulhaOleh](https://github.com/ShulhaOleh) |
+| [Українська (uk)](apps/desktop/src/renderer/src/i18n/uk.json) | <img src="assets/i18n/status/uk.svg" alt="Українська (uk): 424 accepted, 0 review, 36 missing; 92.2%."> 92.2% | [ShevRuslan1](https://github.com/ShevRuslan1) |
+| [中文（中国） (zh-CN)](apps/desktop/src/renderer/src/i18n/zh-CN.json) | <img src="assets/i18n/status/zh-CN.svg" alt="中文（中国） (zh-CN): 456 accepted, 0 review, 4 missing; 99.1%."> 99.1% | [illianezheviasov](https://github.com/illianezheviasov) |
 
 <div class="i18n-status-legend"><img src="assets/i18n/status/legend/accepted.svg" alt=""> Accepted <img src="assets/i18n/status/legend/review.svg" alt=""> Review <img src="assets/i18n/status/legend/missing.svg" alt=""> Missing</div>
 

--- a/README.md
+++ b/README.md
@@ -150,12 +150,12 @@ back to English in the app.
 <!-- prettier-ignore -->
 | Language | Translation | Contributors |
 | --- | --- | --- |
-| [English (en)](apps/desktop/src/renderer/src/i18n/en.json) | <img src="assets/i18n/status/en.svg" alt="English source: 456 valid strings."> Complete | - |
-| [Deutsch (de)](apps/desktop/src/renderer/src/i18n/de.json) | <img src="assets/i18n/status/de.svg" alt="Deutsch (de): 456 accepted, 0 review, 0 missing; Complete."> Complete | [TarekLP](https://github.com/TarekLP) |
-| [Italiano (it)](apps/desktop/src/renderer/src/i18n/it.json) | <img src="assets/i18n/status/it.svg" alt="Italiano (it): 424 accepted, 0 review, 32 missing; 93%."> 93% | [Enderbox89](https://github.com/Enderbox89) |
-| [Русский (ru)](apps/desktop/src/renderer/src/i18n/ru.json) | <img src="assets/i18n/status/ru.svg" alt="Русский (ru): 424 accepted, 0 review, 32 missing; 93%."> 93% | [ShulhaOleh](https://github.com/ShulhaOleh) |
-| [Українська (uk)](apps/desktop/src/renderer/src/i18n/uk.json) | <img src="assets/i18n/status/uk.svg" alt="Українська (uk): 424 accepted, 0 review, 32 missing; 93%."> 93% | [ShevRuslan1](https://github.com/ShevRuslan1) |
-| [中文（中国） (zh-CN)](apps/desktop/src/renderer/src/i18n/zh-CN.json) | <img src="assets/i18n/status/zh-CN.svg" alt="中文（中国） (zh-CN): 456 accepted, 0 review, 0 missing; Complete."> Complete | [illianezheviasov](https://github.com/illianezheviasov) |
+| [English (en)](apps/desktop/src/renderer/src/i18n/en.json) | <img src="assets/i18n/status/en.svg" alt="English source: 459 valid strings."> Complete | - |
+| [Deutsch (de)](apps/desktop/src/renderer/src/i18n/de.json) | <img src="assets/i18n/status/de.svg" alt="Deutsch (de): 456 accepted, 0 review, 3 missing; 99.3%."> 99.3% | [TarekLP](https://github.com/TarekLP) |
+| [Italiano (it)](apps/desktop/src/renderer/src/i18n/it.json) | <img src="assets/i18n/status/it.svg" alt="Italiano (it): 424 accepted, 0 review, 35 missing; 92.4%."> 92.4% | [Enderbox89](https://github.com/Enderbox89) |
+| [Русский (ru)](apps/desktop/src/renderer/src/i18n/ru.json) | <img src="assets/i18n/status/ru.svg" alt="Русский (ru): 424 accepted, 0 review, 35 missing; 92.4%."> 92.4% | [ShulhaOleh](https://github.com/ShulhaOleh) |
+| [Українська (uk)](apps/desktop/src/renderer/src/i18n/uk.json) | <img src="assets/i18n/status/uk.svg" alt="Українська (uk): 424 accepted, 0 review, 35 missing; 92.4%."> 92.4% | [ShevRuslan1](https://github.com/ShevRuslan1) |
+| [中文（中国） (zh-CN)](apps/desktop/src/renderer/src/i18n/zh-CN.json) | <img src="assets/i18n/status/zh-CN.svg" alt="中文（中国） (zh-CN): 456 accepted, 0 review, 3 missing; 99.3%."> 99.3% | [illianezheviasov](https://github.com/illianezheviasov) |
 
 <div class="i18n-status-legend"><img src="assets/i18n/status/legend/accepted.svg" alt=""> Accepted <img src="assets/i18n/status/legend/review.svg" alt=""> Review <img src="assets/i18n/status/legend/missing.svg" alt=""> Missing</div>
 

--- a/apps/desktop/src-tauri/src/commands/conformance_tests.rs
+++ b/apps/desktop/src-tauri/src/commands/conformance_tests.rs
@@ -223,8 +223,9 @@ fn state_round_trips_for_every_game_and_target() {
                 folders: vec![],
                 mods: mods.clone(),
             },
-        );
-        let read = read_state(&state_path);
+        )
+        .unwrap();
+        let read = read_state(&state_path).unwrap();
 
         assert_eq!(read.mods.len(), mods.len(), "{} mod count", spec.id);
         for (got, want) in read.mods.iter().zip(&mods) {

--- a/apps/desktop/src-tauri/src/commands/launchers/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/launchers/mod.rs
@@ -71,16 +71,43 @@ fn probe_one(game: &'static GameDef, launcher_id: &str) -> Option<String> {
 /// save_state creates that file in whichever copy is pointed at, even briefly and even when
 /// it finds nothing: a copy that was selected by mistake for one session comes out of that
 /// looking exactly like the one being modded.
-fn tracked_mod_count(game_path: &str, cfg: &ModEngineConfig) -> usize {
-    let live = read_state(&get_state_path(game_path, cfg)).mods.len();
+/// None when a copy's mod list exists but cannot be read. Counting that as zero would let a
+/// copy holding mods lose the comparison below and hand the game to another store for good.
+fn tracked_mod_count(game_path: &str, cfg: &ModEngineConfig) -> Option<usize> {
+    let count = |path: std::path::PathBuf| match read_state(&path) {
+        Ok(state) => Some(state.mods.len()),
+        Err(e) => {
+            log::warn!("tracked mod count for {}: {e}", cfg.game_id);
+            None
+        }
+    };
+    let live = count(get_state_path(game_path, cfg))?;
     if live > 0 {
-        return live;
+        return Some(live);
     }
     // Launching without mods renames the whole folder for pak games, so until the next
     // launch restores it the list lives inside the backup instead.
-    read_state(&backup_dir(game_path, cfg.primary()).join(crate::commands::mods::STATE_FILENAME))
-        .mods
-        .len()
+    count(backup_dir(game_path, cfg.primary()).join(crate::commands::mods::STATE_FILENAME))
+}
+
+/// What the tracked-mod comparison could conclude about which copy to settle on.
+enum Pick {
+    Chosen(DetectedInstall),
+    NoneFound,
+    /// A copy's mod list could not be read, so the comparison that decides between copies is
+    /// unsound. Settling now could pin the wrong copy permanently, so this run settles
+    /// nothing and the next one decides with a readable list.
+    Unknown,
+}
+
+impl Pick {
+    #[cfg(test)]
+    fn chosen(self) -> Option<DetectedInstall> {
+        match self {
+            Pick::Chosen(install) => Some(install),
+            Pick::NoneFound | Pick::Unknown => None,
+        }
+    }
 }
 
 /// The copy to settle on when nothing has been settled yet. Copies from two stores share no
@@ -92,11 +119,18 @@ fn pick_install(
     installs: &[DetectedInstall],
     cfg: &ModEngineConfig,
     recorded: Option<&str>,
-) -> Option<DetectedInstall> {
-    let counts: Vec<usize> = installs
+) -> Pick {
+    // One copy needs no comparison, so an unreadable mod list cannot mislead it.
+    if let [only] = installs {
+        return Pick::Chosen(only.clone());
+    }
+    let Some(counts) = installs
         .iter()
         .map(|install| tracked_mod_count(&install.game_path, cfg))
-        .collect();
+        .collect::<Option<Vec<usize>>>()
+    else {
+        return Pick::Unknown;
+    };
     let most = counts.iter().copied().max().unwrap_or(0);
     let candidates: Vec<&DetectedInstall> = installs
         .iter()
@@ -109,7 +143,8 @@ fn pick_install(
         .iter()
         .find(|install| Some(install.launcher.as_str()) == recorded)
         .or_else(|| candidates.first())
-        .map(|install| (*install).clone())
+        .map(|install| Pick::Chosen((*install).clone()))
+        .unwrap_or(Pick::NoneFound)
 }
 
 // ── OS helpers ────────────────────────────────────────────────────────────────
@@ -370,12 +405,14 @@ fn resolve_install(
         Resolution::Settle => {
             let installs = probe_installs(game_def);
             match pick_install(&installs, cfg, existing.launcher.as_deref()) {
-                Some(best) => (Some(best.game_path), Some(best.launcher), true),
+                Pick::Chosen(best) => (Some(best.game_path), Some(best.launcher), true),
                 // No store has it, but a folder picked by hand is still a usable copy.
-                None if saved_path_valid(game_def, existing) => {
+                Pick::NoneFound if saved_path_valid(game_def, existing) => {
                     (existing.game_path.clone(), existing.launcher.clone(), true)
                 }
-                None => (None, None, false),
+                Pick::NoneFound => (None, None, false),
+                // Keep what is saved and stay unsettled rather than pin a guess.
+                Pick::Unknown => (existing.game_path.clone(), existing.launcher.clone(), false),
             }
         }
     }

--- a/apps/desktop/src-tauri/src/commands/launchers/mod_tests.rs
+++ b/apps/desktop/src-tauri/src/commands/launchers/mod_tests.rs
@@ -633,6 +633,44 @@ fn pick_falls_back_to_the_first_copy_when_nothing_else_decides() {
     assert!(pick_install(&[], pd3_engine(), None).chosen().is_none());
 }
 
+// Counting an unreadable mod list as zero is how the copy holding the mods loses this
+// comparison and the game gets handed to the other store for good. Nothing is settled until
+// the list can be read.
+#[test]
+fn pick_settles_nothing_when_a_copy_s_mod_list_cannot_be_read() {
+    let steam = TempDir::new().unwrap();
+    let xbox = TempDir::new().unwrap();
+    let steam_path = make_pd3_copy(steam.path(), 0);
+    let xbox_path = make_pd3_copy(xbox.path(), 142);
+    let state = get_state_path(&xbox_path, pd3_engine());
+    std::fs::write(&state, b"{ not json").unwrap();
+
+    let picked = pick_install(
+        &[install("steam", &steam_path), install("xbox", &xbox_path)],
+        pd3_engine(),
+        None,
+    );
+
+    assert!(
+        matches!(picked, Pick::Unknown),
+        "an unreadable mod list must not resolve to a choice"
+    );
+}
+
+// One copy needs no comparison at all, so an unreadable list there changes nothing.
+#[test]
+fn pick_still_settles_on_a_single_copy_with_an_unreadable_mod_list() {
+    let only = TempDir::new().unwrap();
+    let path = make_pd3_copy(only.path(), 3);
+    std::fs::write(get_state_path(&path, pd3_engine()), b"{ not json").unwrap();
+
+    let picked = pick_install(&[install("steam", &path)], pd3_engine(), None)
+        .chosen()
+        .unwrap();
+
+    assert_eq!(picked.launcher, "steam");
+}
+
 fn settled_on(path: &str, launcher: &str) -> GameSettings {
     GameSettings {
         game_path: Some(path.to_string()),

--- a/apps/desktop/src-tauri/src/commands/launchers/mod_tests.rs
+++ b/apps/desktop/src-tauri/src/commands/launchers/mod_tests.rs
@@ -505,7 +505,8 @@ fn make_pd3_copy(root: &Path, mod_count: usize) -> String {
             mods,
             folders: vec![],
         },
-    );
+    )
+    .unwrap();
     game_path
 }
 
@@ -532,7 +533,9 @@ fn pick_prefers_the_copy_tracking_the_most_mods() {
     let xbox_path = make_pd3_copy(xbox.path(), 142);
     let installs = vec![install("steam", &steam_path), install("xbox", &xbox_path)];
 
-    let picked = pick_install(&installs, pd3_engine(), None).unwrap();
+    let picked = pick_install(&installs, pd3_engine(), None)
+        .chosen()
+        .unwrap();
     assert_eq!(picked.launcher, "xbox");
     assert_eq!(picked.game_path, xbox_path);
 }
@@ -549,7 +552,9 @@ fn pick_ignores_a_mod_list_left_behind_by_a_copy_that_was_only_pointed_at() {
         install("xbox", &make_pd3_copy(xbox.path(), 142)),
     ];
 
-    let picked = pick_install(&installs, pd3_engine(), None).unwrap();
+    let picked = pick_install(&installs, pd3_engine(), None)
+        .chosen()
+        .unwrap();
     assert_eq!(picked.launcher, "xbox");
 }
 
@@ -571,10 +576,13 @@ fn pick_counts_mods_hidden_in_a_backup() {
             mods: vec![InstalledMod::default()],
             folders: vec![],
         },
-    );
+    )
+    .unwrap();
 
     let installs = vec![install("steam", &steam_path), install("xbox", &xbox_path)];
-    let picked = pick_install(&installs, pd3_engine(), None).unwrap();
+    let picked = pick_install(&installs, pd3_engine(), None)
+        .chosen()
+        .unwrap();
     assert_eq!(picked.launcher, "xbox");
 }
 
@@ -587,7 +595,9 @@ fn pick_falls_back_to_the_recorded_launcher_when_no_copy_has_mods() {
         install("xbox", &make_bare_pd3_copy(xbox.path())),
     ];
 
-    let picked = pick_install(&installs, pd3_engine(), Some("xbox")).unwrap();
+    let picked = pick_install(&installs, pd3_engine(), Some("xbox"))
+        .chosen()
+        .unwrap();
     assert_eq!(picked.launcher, "xbox");
 }
 
@@ -601,7 +611,9 @@ fn pick_keeps_the_recorded_launcher_when_both_copies_are_equally_modded() {
         install("xbox", &make_pd3_copy(xbox.path(), 3)),
     ];
 
-    let picked = pick_install(&installs, pd3_engine(), Some("xbox")).unwrap();
+    let picked = pick_install(&installs, pd3_engine(), Some("xbox"))
+        .chosen()
+        .unwrap();
     assert_eq!(picked.launcher, "xbox");
 }
 
@@ -614,9 +626,11 @@ fn pick_falls_back_to_the_first_copy_when_nothing_else_decides() {
         install("xbox", &make_bare_pd3_copy(xbox.path())),
     ];
 
-    let picked = pick_install(&installs, pd3_engine(), None).unwrap();
+    let picked = pick_install(&installs, pd3_engine(), None)
+        .chosen()
+        .unwrap();
     assert_eq!(picked.launcher, "steam");
-    assert!(pick_install(&[], pd3_engine(), None).is_none());
+    assert!(pick_install(&[], pd3_engine(), None).chosen().is_none());
 }
 
 fn settled_on(path: &str, launcher: &str) -> GameSettings {

--- a/apps/desktop/src-tauri/src/commands/mods/folders.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/folders.rs
@@ -2,7 +2,7 @@ use super::engine::ModEngineConfig;
 use super::naming::log_name;
 use super::naming::{apply_priority_prefix, strip_priority_prefix};
 use super::paths::{active_mod_path, disabled_base, disabled_mod_path, mods_base};
-use super::state::{get_folder_path, read_state, save_state};
+use super::state::{get_folder_path, read_state, save_error, save_state};
 use super::types::ModFolder;
 use std::fs;
 use std::path::Path;
@@ -15,7 +15,7 @@ pub fn create_folder_op(
     parent_id: Option<String>,
     cfg: &ModEngineConfig,
 ) -> Result<ModFolder, String> {
-    let mut state = read_state(state_path);
+    let mut state = read_state(state_path).map_err(|e| e.to_string())?;
 
     if let Some(existing) = state
         .folders
@@ -66,7 +66,7 @@ pub fn create_folder_op(
         parent_id,
     };
     state.folders.push(folder.clone());
-    save_state(state_path, &state);
+    save_state(state_path, &state).map_err(save_error)?;
     Ok(folder)
 }
 
@@ -76,19 +76,19 @@ pub fn move_folder_op(
     folder_id: &str,
     target_parent_id: Option<String>,
     cfg: &ModEngineConfig,
-) {
-    let mut state = read_state(state_path);
+) -> Result<(), String> {
+    let mut state = read_state(state_path).map_err(|e| e.to_string())?;
     let Some(folder) = state.folders.iter().find(|f| f.id == folder_id).cloned() else {
-        return;
+        return Ok(());
     };
     if folder.parent_id == target_parent_id {
-        return;
+        return Ok(());
     }
 
     let mut cur = target_parent_id.clone();
     while let Some(ref cid) = cur {
         if cid == folder_id {
-            return;
+            return Ok(());
         }
         cur = state
             .folders
@@ -160,7 +160,8 @@ pub fn move_folder_op(
         }
     }
 
-    save_state(state_path, &state);
+    save_state(state_path, &state).map_err(save_error)?;
+    Ok(())
 }
 
 pub fn rename_folder_op(
@@ -169,10 +170,10 @@ pub fn rename_folder_op(
     folder_id: &str,
     display_name: &str,
     cfg: &ModEngineConfig,
-) {
-    let mut state = read_state(state_path);
+) -> Result<(), String> {
+    let mut state = read_state(state_path).map_err(|e| e.to_string())?;
     let Some(folder) = state.folders.iter().find(|f| f.id == folder_id).cloned() else {
-        return;
+        return Ok(());
     };
 
     let slug: String = display_name
@@ -229,7 +230,8 @@ pub fn rename_folder_op(
             f.disk_name = new_disk_name.clone();
         }
     }
-    save_state(state_path, &state);
+    save_state(state_path, &state).map_err(save_error)?;
+    Ok(())
 }
 
 pub fn delete_folder_op(
@@ -237,10 +239,10 @@ pub fn delete_folder_op(
     state_path: &Path,
     folder_id: &str,
     cfg: &ModEngineConfig,
-) {
-    let mut state = read_state(state_path);
+) -> Result<(), String> {
+    let mut state = read_state(state_path).map_err(|e| e.to_string())?;
     let Some(folder) = state.folders.iter().find(|f| f.id == folder_id).cloned() else {
-        return;
+        return Ok(());
     };
 
     let target_parent_id = folder.parent_id.clone();
@@ -388,5 +390,6 @@ pub fn delete_folder_op(
     }
 
     state.folders.retain(|f| f.id != folder_id);
-    save_state(state_path, &state);
+    save_state(state_path, &state).map_err(save_error)?;
+    Ok(())
 }

--- a/apps/desktop/src-tauri/src/commands/mods/identity_tests.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/identity_tests.rs
@@ -318,7 +318,7 @@ fn old_state_without_the_new_fields_loads_enriches_saves_and_reloads() {
             "sha256":"b021ffae","updateStatus":"unknown"}"#,
     );
 
-    let mut state = read_state(&state_path);
+    let mut state = read_state(&state_path).unwrap();
     assert_eq!(state.mods[0].identity, None);
 
     let cfg = engine_for_game("pd2").unwrap();
@@ -330,9 +330,9 @@ fn old_state_without_the_new_fields_loads_enriches_saves_and_reloads() {
         None,
     );
     assert!(changed);
-    save_state(&state_path, &state);
+    save_state(&state_path, &state).unwrap();
 
-    let reloaded = read_state(&state_path);
+    let reloaded = read_state(&state_path).unwrap();
     let identity = reloaded.mods[0].identity.as_ref().unwrap();
     assert_eq!(identity.namespace, "pd2mods.z77.fr");
     assert_eq!(identity.key, "Celer");
@@ -350,7 +350,10 @@ fn an_identity_whose_namespace_was_still_a_key_prefix_still_loads() {
             "identity":{"key":"github:vojin154/repo#Check For Wallbangs","evidence":"repository"}}"#,
     );
 
-    let identity = read_state(&state_path).mods[0].identity.clone().unwrap();
+    let identity = read_state(&state_path).unwrap().mods[0]
+        .identity
+        .clone()
+        .unwrap();
 
     assert_eq!(identity.namespace, "github");
     assert_eq!(identity.key, "vojin154/repo#Check For Wallbangs");
@@ -367,7 +370,10 @@ fn a_persisted_confidence_never_overrides_the_evidence_it_came_from() {
                         "evidence":"nameAuthor","confidence":"exact"}}"#,
     );
 
-    let identity = read_state(&state_path).mods[0].identity.clone().unwrap();
+    let identity = read_state(&state_path).unwrap().mods[0]
+        .identity
+        .clone()
+        .unwrap();
 
     assert_eq!(identity.confidence, IdentityConfidence::Candidate);
 }

--- a/apps/desktop/src-tauri/src/commands/mods/install.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/install.rs
@@ -515,35 +515,44 @@ fn set_activation(
     fs::create_dir_all(&destination_parent)
         .map_err(|e| format!("could not prepare the destination folder: {e}"))?;
 
+    let activation_is_external = cfg.game_id == "cb";
+    let placement = observe_placement(&active, &disabled, target);
+    if placement == Placement::Both {
+        return Err(format!(
+            "'{}' is in both the active and disabled folders, so Modrex will not guess which copy to keep",
+            m.name
+        ));
+    }
+    if placement == Placement::Missing && !activation_is_external {
+        return Err(format!(
+            "'{}' is no longer where Modrex installed it",
+            m.name
+        ));
+    }
+
     // Crime Boss's own mod loader reads activation from its settings file, not from where the
     // files sit, so that write is the one that takes effect and the move below is bookkeeping.
     // resync_crimeboss_enabled_flags also flips the tracked flag without moving anything, so a
-    // mod whose files are not where Modrex expects is normal here.
-    let activation_is_external = cfg.game_id == "cb";
+    // mod whose files are not where Modrex expects is normal here. Every failure past this
+    // point puts the file back, because the game reads it the moment it is written and a
+    // command that returned an error would have activated the mod anyway.
     if activation_is_external {
         let cb_path = if from.exists() { from } else { to };
         crimeboss_settings::sync_enabled(cb_path, target.is_directory_unit(), launcher, enable);
     }
 
     // Only a move that actually happened can be put back, so the branches that move nothing
-    // say so rather than leaving a reversal to undo something this call never did.
-    let moved = match observe_placement(&active, &disabled, target) {
-        // Already where this operation wanted it. The record is what is out of step, so
-        // correct that and move nothing.
-        p if p == wanted_placement(enable) => false,
-        Placement::Both => {
-            return Err(format!(
-                "'{}' is in both the active and disabled folders, so Modrex will not guess which copy to keep",
-                m.name
-            ))
-        }
-        Placement::Missing if !activation_is_external => {
-            return Err(format!("'{}' is no longer where Modrex installed it", m.name))
-        }
-        Placement::Missing => false,
-        _ => {
-            move_mod_object(from, to, target)?;
-            true
+    // say so rather than leaving a reversal to undo something this call never did. Already
+    // being where this operation wanted it leaves the record as the only thing out of step.
+    let moved = if placement == wanted_placement(enable) || placement == Placement::Missing {
+        false
+    } else {
+        match move_mod_object(from, to, target) {
+            Ok(()) => true,
+            Err(e) => {
+                undo_external_activation(&active, &disabled, target, launcher, enable, cfg);
+                return Err(e);
+            }
         }
     };
 
@@ -557,9 +566,33 @@ fn set_activation(
     };
     let failure = save_error(e);
     if !moved {
+        undo_external_activation(&active, &disabled, target, launcher, enable, cfg);
         return Err(failure);
     }
-    Err(undo_after_failed_save(to, from, target, failure))
+    let failure = undo_after_failed_save(to, from, target, failure);
+    undo_external_activation(&active, &disabled, target, launcher, enable, cfg);
+    Err(failure)
+}
+
+/// Puts Crime Boss's own activation switch back after the rest of the operation failed.
+///
+/// That settings file, not the folder the files sit in, is what the game reads, so leaving it
+/// flipped would activate a mod the command has just reported as unchanged. Runs after any file
+/// reversal so it reads whichever copy is on disk by then. Does nothing for every other game,
+/// where the move itself is the activation.
+fn undo_external_activation(
+    active: &Path,
+    disabled: &Path,
+    target: &ScanTarget,
+    launcher: Option<&str>,
+    enable: bool,
+    cfg: &ModEngineConfig,
+) {
+    if cfg.game_id != "cb" {
+        return;
+    }
+    let path = if active.exists() { active } else { disabled };
+    crimeboss_settings::sync_enabled(path, target.is_directory_unit(), launcher, !enable);
 }
 
 fn wanted_placement(enable: bool) -> Placement {

--- a/apps/desktop/src-tauri/src/commands/mods/install.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/install.rs
@@ -388,6 +388,51 @@ pub fn uninstall_mod_op(
     Ok(())
 }
 
+/// Where a mod's primary object actually sits.
+///
+/// Each location is checked against the kind its target expects, because a bare exists() says
+/// only that the path is taken. A directory standing where a pak belongs is exactly what an
+/// interrupted move leaves behind, and reading that as "the mod is here" gets the answer
+/// backwards in the one case this check exists for.
+#[derive(Debug, PartialEq, Eq)]
+enum Placement {
+    Active,
+    Disabled,
+    /// Both locations hold it. The active copy is the one the game loads, but a duplicate is
+    /// reported rather than quietly resolved to a boolean.
+    Both,
+    /// Neither holds it, so nothing on disk says whether this mod is enabled.
+    Missing,
+}
+
+fn holds_mod(target: &ScanTarget, path: &Path) -> bool {
+    match &target.unit {
+        ModUnit::File { .. } => path.is_file(),
+        ModUnit::Directory { .. } => path.is_dir(),
+    }
+}
+
+fn observe_placement(active: &Path, disabled: &Path, target: &ScanTarget) -> Placement {
+    match (holds_mod(target, active), holds_mod(target, disabled)) {
+        (true, false) => Placement::Active,
+        (false, true) => Placement::Disabled,
+        (true, true) => Placement::Both,
+        (false, false) => Placement::Missing,
+    }
+}
+
+fn move_mod_object(from: &Path, to: &Path, target: &ScanTarget) -> Result<(), String> {
+    match &target.unit {
+        ModUnit::File { extension, .. } => {
+            rename_with_sidecars(from, to, extension, target.companions)
+        }
+        // A directory unit has no companions, so its move is the single rename.
+        ModUnit::Directory { .. } => {
+            fs::rename(from, to).map_err(|e| format!("could not move {}: {e}", log_name(from)))
+        }
+    }
+}
+
 pub fn enable_mod_op(
     game_path: &str,
     state_path: &Path,
@@ -395,67 +440,177 @@ pub fn enable_mod_op(
     cfg: &ModEngineConfig,
     launcher: Option<&str>,
 ) -> Result<(), String> {
+    set_activation(game_path, state_path, uid, cfg, launcher, true)
+}
+
+pub fn disable_mod_op(
+    game_path: &str,
+    state_path: &Path,
+    uid: &str,
+    cfg: &ModEngineConfig,
+    launcher: Option<&str>,
+) -> Result<(), String> {
+    set_activation(game_path, state_path, uid, cfg, launcher, false)
+}
+
+/// Moves a mod between the active and disabled locations and records the result, in that
+/// order.
+///
+/// The order is what makes the failure cases honest. A move that did not happen returns
+/// before the flag is touched, so nothing claims a change the disk does not show. A save that
+/// fails after a successful move puts the files back, because the record cannot describe them
+/// otherwise: the scan reads a mod as known wherever it sits, so a disagreement between the
+/// two would never be noticed again.
+fn set_activation(
+    game_path: &str,
+    state_path: &Path,
+    uid: &str,
+    cfg: &ModEngineConfig,
+    launcher: Option<&str>,
+    enable: bool,
+) -> Result<(), String> {
     let mut state = read_state(state_path).map_err(|e| e.to_string())?;
     let Some(m) = state
         .mods
         .iter()
-        .find(|m| m.uid == uid && !m.enabled)
+        .find(|m| m.uid == uid && m.enabled != enable)
         .cloned()
     else {
         return Ok(());
     };
-    log::info!("enable: {} ({})", m.name, m.uid);
-    // Host packs move back from our disabled area into the host mod's folder.
+    let action = if enable { "enable" } else { "disable" };
+    log::info!("{action}: {} ({})", m.name, m.uid);
+
+    // Host packs live inside another mod's folder rather than at a target root.
     if is_host_pack(&m) {
-        return move_host_pack(game_path, state_path, &mut state, &m, uid, cfg, true);
+        return move_host_pack(game_path, state_path, &mut state, &m, uid, cfg, enable);
     }
+
     let target = cfg.target_for(m.location.as_deref());
     if target.enabled_state == Activation::Ue4ssModsTxt {
-        let mods_txt = mods_base(game_path, target).join("mods.txt");
-        ue4ss_modstxt::sync_enabled(&mods_txt, &m.filename, true);
-        for m in state.mods.iter_mut() {
-            if m.uid == uid {
-                m.enabled = true;
-            }
-        }
-        save_state(state_path, &state).map_err(save_error)?;
-        return Ok(());
+        return set_activation_in_mods_txt(
+            game_path, state_path, &mut state, &m, uid, target, enable,
+        );
     }
+
     let rel = get_folder_path(&state.folders, m.folder_id.as_deref());
-    if let Some(r) = &rel {
-        if let Err(e) = fs::create_dir_all(mods_base(game_path, target).join(r)) {
-            log::warn!("enable_mod: create_dir_all: {e}");
+    let active = active_mod_path(game_path, &m.filename, rel.as_deref(), target);
+    let disabled = disabled_mod_path(game_path, &m.filename, rel.as_deref(), target);
+    let (from, to) = if enable {
+        (&disabled, &active)
+    } else {
+        (&active, &disabled)
+    };
+    let destination_parent = if enable {
+        match &rel {
+            Some(r) => mods_base(game_path, target).join(r),
+            None => mods_base(game_path, target),
         }
-    }
-    let from = disabled_mod_path(game_path, &m.filename, rel.as_deref(), target);
-    let to = active_mod_path(game_path, &m.filename, rel.as_deref(), target);
-    // The game's own UGC mod-loader, not this file move, is what actually controls whether a
-    // Crime Boss mod is active. See crimeboss_settings.rs.
-    // resync_crimeboss_enabled_flags flips m.enabled without moving files, so from may not
-    // exist. Fall back to to when deriving the settings path from the pak.
-    if cfg.game_id == "cb" {
-        let cb_path = if from.exists() { &from } else { &to };
-        crimeboss_settings::sync_enabled(cb_path, target.is_directory_unit(), launcher, true);
-    }
-    if from.exists() {
-        let renamed = match &target.unit {
-            ModUnit::File { extension, .. } => {
-                rename_with_sidecars(&from, &to, extension, target.companions)
-            }
-            ModUnit::Directory { .. } => fs::rename(&from, &to)
-                .map_err(|e| format!("could not move {}: {e}", log_name(&from))),
-        };
-        if let Err(e) = renamed {
-            log::warn!("enable_mod: rename {from:?} -> {to:?}: {e}");
+    } else {
+        match &rel {
+            Some(r) => disabled_base(game_path, target).join(r),
+            None => disabled_base(game_path, target),
         }
+    };
+    fs::create_dir_all(&destination_parent)
+        .map_err(|e| format!("could not prepare the destination folder: {e}"))?;
+
+    // Crime Boss's own mod loader reads activation from its settings file, not from where the
+    // files sit, so that write is the one that takes effect and the move below is bookkeeping.
+    // resync_crimeboss_enabled_flags also flips the tracked flag without moving anything, so a
+    // mod whose files are not where Modrex expects is normal here.
+    let activation_is_external = cfg.game_id == "cb";
+    if activation_is_external {
+        let cb_path = if from.exists() { from } else { to };
+        crimeboss_settings::sync_enabled(cb_path, target.is_directory_unit(), launcher, enable);
     }
+
+    match observe_placement(&active, &disabled, target) {
+        // Already where this operation wanted it. The record is what is out of step, so
+        // correct that and move nothing.
+        p if p == wanted_placement(enable) => {}
+        Placement::Both => {
+            return Err(format!(
+                "'{}' is in both the active and disabled folders, so Modrex will not guess which copy to keep",
+                m.name
+            ))
+        }
+        Placement::Missing if !activation_is_external => {
+            return Err(format!("'{}' is no longer where Modrex installed it", m.name))
+        }
+        Placement::Missing => {}
+        _ => move_mod_object(from, to, target)?,
+    }
+
     for m in state.mods.iter_mut() {
         if m.uid == uid {
-            m.enabled = true;
+            m.enabled = enable;
         }
     }
-    save_state(state_path, &state).map_err(save_error)?;
+    if let Err(e) = save_state(state_path, &state) {
+        return Err(undo_after_failed_save(to, from, target, save_error(e)));
+    }
     Ok(())
+}
+
+fn wanted_placement(enable: bool) -> Placement {
+    if enable {
+        Placement::Active
+    } else {
+        Placement::Disabled
+    }
+}
+
+/// Puts the files back after the record could not be written, and composes both failures.
+///
+/// No second save follows a complete reversal: the file on disk was never replaced, so it
+/// already describes the restored layout. A reversal that fails leaves the move standing and
+/// the record behind it, which the message has to say outright.
+fn undo_after_failed_save(
+    from: &Path,
+    to: &Path,
+    target: &ScanTarget,
+    save_failure: String,
+) -> String {
+    match move_mod_object(from, to, target) {
+        Ok(()) => save_failure,
+        Err(undo) => {
+            format!("{save_failure}; the files were moved and could not be put back either: {undo}")
+        }
+    }
+}
+
+/// UE4SS loads whichever folders its own mods.txt lists, so that file is the activation and
+/// the folder never moves. A record that cannot be written is put back the same way a file
+/// move is.
+fn set_activation_in_mods_txt(
+    game_path: &str,
+    state_path: &Path,
+    state: &mut ModsState,
+    m: &InstalledMod,
+    uid: &str,
+    target: &ScanTarget,
+    enable: bool,
+) -> Result<(), String> {
+    let mods_txt = mods_base(game_path, target).join("mods.txt");
+    ue4ss_modstxt::set_enabled(&mods_txt, &m.filename, enable)?;
+    for x in state.mods.iter_mut() {
+        if x.uid == uid {
+            x.enabled = enable;
+        }
+    }
+    let Err(e) = save_state(state_path, state) else {
+        return Ok(());
+    };
+    let failure = save_error(e);
+    Err(
+        match ue4ss_modstxt::set_enabled(&mods_txt, &m.filename, !enable) {
+            Ok(()) => failure,
+            Err(undo) => {
+                format!("{failure}; the loader's own list could not be put back either: {undo}")
+            }
+        },
+    )
 }
 
 /// Moves a host pack between the host mod's folder and Modrex's disabled area, then flips its
@@ -469,98 +624,55 @@ fn move_host_pack(
     cfg: &ModEngineConfig,
     enable: bool,
 ) -> Result<(), String> {
-    let active = host_pack_dir(game_path, cfg, &state.mods, &state.folders, m);
-    let disabled = host_pack_disabled_dir(game_path, cfg, m);
-    if let (Some(active), Some(disabled)) = (active, disabled) {
-        let (from, to) = if enable {
-            (disabled, active)
-        } else {
-            (active, disabled)
-        };
-        if from.exists() {
-            if let Some(parent) = to.parent() {
-                let _ = fs::create_dir_all(parent);
-            }
-            if let Err(e) = fs::rename(&from, &to) {
-                log::warn!("move host pack {from:?} -> {to:?}: {e}");
-            }
+    let (Some(active), Some(disabled)) = (
+        host_pack_dir(game_path, cfg, &state.mods, &state.folders, m),
+        host_pack_disabled_dir(game_path, cfg, m),
+    ) else {
+        return Err(format!(
+            "'{}' is a content pack for a mod that is no longer installed",
+            m.name
+        ));
+    };
+    let (from, to) = if enable {
+        (disabled, active)
+    } else {
+        (active, disabled)
+    };
+    // A pack that is already at the destination only needs its record corrected.
+    let moved = if from.is_dir() {
+        if let Some(parent) = to.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|e| format!("could not prepare the destination folder: {e}"))?;
         }
-    }
+        fs::rename(&from, &to).map_err(|e| format!("could not move {}: {e}", log_name(&from)))?;
+        true
+    } else if !to.is_dir() {
+        return Err(format!(
+            "'{}' is no longer where Modrex installed it",
+            m.name
+        ));
+    } else {
+        false
+    };
+
     for x in state.mods.iter_mut() {
         if x.uid == uid {
             x.enabled = enable;
         }
     }
-    save_state(state_path, state).map_err(save_error)?;
-    Ok(())
-}
-
-pub fn disable_mod_op(
-    game_path: &str,
-    state_path: &Path,
-    uid: &str,
-    cfg: &ModEngineConfig,
-    launcher: Option<&str>,
-) -> Result<(), String> {
-    let mut state = read_state(state_path).map_err(|e| e.to_string())?;
-    let Some(m) = state
-        .mods
-        .iter()
-        .find(|m| m.uid == uid && m.enabled)
-        .cloned()
-    else {
+    let Err(e) = save_state(state_path, state) else {
         return Ok(());
     };
-    log::info!("disable: {} ({})", m.name, m.uid);
-    // Host packs move out of the host mod's folder into our disabled area.
-    if is_host_pack(&m) {
-        return move_host_pack(game_path, state_path, &mut state, &m, uid, cfg, false);
+    let failure = save_error(e);
+    if !moved {
+        return Err(failure);
     }
-    let target = cfg.target_for(m.location.as_deref());
-    if target.enabled_state == Activation::Ue4ssModsTxt {
-        let mods_txt = mods_base(game_path, target).join("mods.txt");
-        ue4ss_modstxt::sync_enabled(&mods_txt, &m.filename, false);
-        for m in state.mods.iter_mut() {
-            if m.uid == uid {
-                m.enabled = false;
-            }
+    Err(match fs::rename(&to, &from) {
+        Ok(()) => failure,
+        Err(undo) => {
+            format!("{failure}; the pack was moved and could not be put back either: {undo}")
         }
-        save_state(state_path, &state).map_err(save_error)?;
-        return Ok(());
-    }
-    let rel = get_folder_path(&state.folders, m.folder_id.as_deref());
-    let dis_dir = match &rel {
-        Some(r) => disabled_base(game_path, target).join(r),
-        None => disabled_base(game_path, target),
-    };
-    if let Err(e) = fs::create_dir_all(&dis_dir) {
-        log::warn!("disable_mod: create_dir_all failed: {e}");
-    }
-    let from = active_mod_path(game_path, &m.filename, rel.as_deref(), target);
-    let to = disabled_mod_path(game_path, &m.filename, rel.as_deref(), target);
-    if cfg.game_id == "cb" {
-        let cb_path = if from.exists() { &from } else { &to };
-        crimeboss_settings::sync_enabled(cb_path, target.is_directory_unit(), launcher, false);
-    }
-    if from.exists() {
-        let renamed = match &target.unit {
-            ModUnit::File { extension, .. } => {
-                rename_with_sidecars(&from, &to, extension, target.companions)
-            }
-            ModUnit::Directory { .. } => fs::rename(&from, &to)
-                .map_err(|e| format!("could not move {}: {e}", log_name(&from))),
-        };
-        if let Err(e) = renamed {
-            log::warn!("disable_mod: rename {from:?} -> {to:?}: {e}");
-        }
-    }
-    for m in state.mods.iter_mut() {
-        if m.uid == uid {
-            m.enabled = false;
-        }
-    }
-    save_state(state_path, &state).map_err(save_error)?;
-    Ok(())
+    })
 }
 
 /// Puts back the moves a failed group move already made, most recent first so each

--- a/apps/desktop/src-tauri/src/commands/mods/install.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/install.rs
@@ -699,7 +699,7 @@ fn undo_moves(moved: &[(std::path::PathBuf, std::path::PathBuf)]) -> Result<(), 
 /// game loads and cannot read. The outputs this call created are removed, leaving a
 /// destination that already existed alone, since undoing an overwrite would need a copy of
 /// what was there.
-fn copy_file_with_sidecars(
+pub(super) fn copy_file_with_sidecars(
     src: &Path,
     dest: &Path,
     main_ext: &str,
@@ -753,7 +753,7 @@ fn copy_file_with_sidecars(
 /// Used by enable and disable, which move a mod between the active and disabled locations. A
 /// companion left behind would split the mod across both, so the moves already made are put
 /// back. The failure is reported either way: a move that had to be undone did not happen.
-fn rename_with_sidecars(
+pub(super) fn rename_with_sidecars(
     from: &Path,
     to: &Path,
     main_ext: &str,
@@ -787,7 +787,7 @@ fn rename_with_sidecars(
 ///
 /// Deletion has no counterpart to undo it, so a companion that will not go is reported and
 /// the caller decides what that means for the mod's record.
-fn remove_file_with_sidecars(
+pub(super) fn remove_file_with_sidecars(
     path: &Path,
     main_ext: &str,
     companions: &[&str],

--- a/apps/desktop/src-tauri/src/commands/mods/install.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/install.rs
@@ -525,10 +525,12 @@ fn set_activation(
         crimeboss_settings::sync_enabled(cb_path, target.is_directory_unit(), launcher, enable);
     }
 
-    match observe_placement(&active, &disabled, target) {
+    // Only a move that actually happened can be put back, so the branches that move nothing
+    // say so rather than leaving a reversal to undo something this call never did.
+    let moved = match observe_placement(&active, &disabled, target) {
         // Already where this operation wanted it. The record is what is out of step, so
         // correct that and move nothing.
-        p if p == wanted_placement(enable) => {}
+        p if p == wanted_placement(enable) => false,
         Placement::Both => {
             return Err(format!(
                 "'{}' is in both the active and disabled folders, so Modrex will not guess which copy to keep",
@@ -538,19 +540,26 @@ fn set_activation(
         Placement::Missing if !activation_is_external => {
             return Err(format!("'{}' is no longer where Modrex installed it", m.name))
         }
-        Placement::Missing => {}
-        _ => move_mod_object(from, to, target)?,
-    }
+        Placement::Missing => false,
+        _ => {
+            move_mod_object(from, to, target)?;
+            true
+        }
+    };
 
     for m in state.mods.iter_mut() {
         if m.uid == uid {
             m.enabled = enable;
         }
     }
-    if let Err(e) = save_state(state_path, &state) {
-        return Err(undo_after_failed_save(to, from, target, save_error(e)));
+    let Err(e) = save_state(state_path, &state) else {
+        return Ok(());
+    };
+    let failure = save_error(e);
+    if !moved {
+        return Err(failure);
     }
-    Ok(())
+    Err(undo_after_failed_save(to, from, target, failure))
 }
 
 fn wanted_placement(enable: bool) -> Placement {

--- a/apps/desktop/src-tauri/src/commands/mods/install.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/install.rs
@@ -7,7 +7,7 @@ use super::paths::{
     active_mod_path, disabled_base, disabled_mod_path, host_pack_dir, host_pack_disabled_dir,
     mods_base, resolve_host_mod_dir,
 };
-use super::state::{get_folder_path, read_state, save_state};
+use super::state::{get_folder_path, read_state, save_error, save_state};
 use super::types::{InstalledMod, ModsState};
 use super::ue4ss_modstxt;
 use super::zip::extract_dir_entry;
@@ -38,7 +38,7 @@ pub fn install_host_pack_op(
         .as_deref()
         .and_then(parse_host_location)
         .ok_or("install_host_pack: mod_data.location is not a host location")?;
-    let mut state = read_state(state_path);
+    let mut state = read_state(state_path).map_err(|e| e.to_string())?;
     let host_dir = resolve_host_mod_dir(game_path, cfg, &state.mods, &state.folders, host_id)
         .ok_or_else(|| {
             let name = host_target_by_id(host_id)
@@ -82,7 +82,8 @@ pub fn install_host_pack_op(
             folders: state.folders,
             mods: state.mods,
         },
-    );
+    )
+    .map_err(save_error)?;
     Ok(())
 }
 
@@ -101,7 +102,7 @@ pub fn install_mod_from_path(
     } else {
         None
     };
-    let state = read_state(state_path);
+    let state = read_state(state_path).map_err(|e| e.to_string())?;
     let folder_rel = get_folder_path(&state.folders, folder_id.as_deref());
 
     let dest_dir = match &folder_rel {
@@ -202,7 +203,8 @@ pub fn install_mod_from_path(
             folders: state.folders,
             mods: new_mods,
         },
-    );
+    )
+    .map_err(save_error)?;
     Ok(())
 }
 
@@ -219,7 +221,7 @@ pub fn move_crimeboss_mod_target_op(
     cfg: &ModEngineConfig,
     launcher: Option<&str>,
 ) -> Result<(), String> {
-    let state = read_state(state_path);
+    let state = read_state(state_path).map_err(|e| e.to_string())?;
     let m = state
         .mods
         .iter()
@@ -307,7 +309,7 @@ pub fn move_crimeboss_mod_target_op(
     // install_mod_from_path always installs as enabled, being written for fresh installs, so
     // restore the disabled state here if the mod wasn't active before the move.
     if !m.enabled {
-        disable_mod_op(game_path, state_path, uid, cfg, launcher);
+        disable_mod_op(game_path, state_path, uid, cfg, launcher)?;
     }
 
     // install_mod_from_path's own "existing" cleanup computes the old path inside the new
@@ -325,10 +327,15 @@ pub fn move_crimeboss_mod_target_op(
     Ok(())
 }
 
-pub fn uninstall_mod_op(game_path: &str, state_path: &Path, uid: &str, cfg: &ModEngineConfig) {
-    let mut state = read_state(state_path);
+pub fn uninstall_mod_op(
+    game_path: &str,
+    state_path: &Path,
+    uid: &str,
+    cfg: &ModEngineConfig,
+) -> Result<(), String> {
+    let mut state = read_state(state_path).map_err(|e| e.to_string())?;
     let Some(m) = state.mods.iter().find(|m| m.uid == uid).cloned() else {
-        return;
+        return Ok(());
     };
     log::info!("uninstall: {} ({})", m.name, m.uid);
     // Host packs live inside another mod's folder or in the disabled area. Remove either.
@@ -347,8 +354,8 @@ pub fn uninstall_mod_op(game_path: &str, state_path: &Path, uid: &str, cfg: &Mod
             }
         }
         state.mods.retain(|x| x.uid != uid);
-        save_state(state_path, &state);
-        return;
+        save_state(state_path, &state).map_err(save_error)?;
+        return Ok(());
     }
     let target = cfg.target_for(m.location.as_deref());
     let rel = get_folder_path(&state.folders, m.folder_id.as_deref());
@@ -372,7 +379,8 @@ pub fn uninstall_mod_op(game_path: &str, state_path: &Path, uid: &str, cfg: &Mod
         }
     }
     state.mods.retain(|m| m.uid != uid);
-    save_state(state_path, &state);
+    save_state(state_path, &state).map_err(save_error)?;
+    Ok(())
 }
 
 pub fn enable_mod_op(
@@ -381,21 +389,20 @@ pub fn enable_mod_op(
     uid: &str,
     cfg: &ModEngineConfig,
     launcher: Option<&str>,
-) {
-    let mut state = read_state(state_path);
+) -> Result<(), String> {
+    let mut state = read_state(state_path).map_err(|e| e.to_string())?;
     let Some(m) = state
         .mods
         .iter()
         .find(|m| m.uid == uid && !m.enabled)
         .cloned()
     else {
-        return;
+        return Ok(());
     };
     log::info!("enable: {} ({})", m.name, m.uid);
     // Host packs move back from our disabled area into the host mod's folder.
     if is_host_pack(&m) {
-        move_host_pack(game_path, state_path, &mut state, &m, uid, cfg, true);
-        return;
+        return move_host_pack(game_path, state_path, &mut state, &m, uid, cfg, true);
     }
     let target = cfg.target_for(m.location.as_deref());
     if target.enabled_state == Activation::Ue4ssModsTxt {
@@ -406,8 +413,8 @@ pub fn enable_mod_op(
                 m.enabled = true;
             }
         }
-        save_state(state_path, &state);
-        return;
+        save_state(state_path, &state).map_err(save_error)?;
+        return Ok(());
     }
     let rel = get_folder_path(&state.folders, m.folder_id.as_deref());
     if let Some(r) = &rel {
@@ -441,7 +448,8 @@ pub fn enable_mod_op(
             m.enabled = true;
         }
     }
-    save_state(state_path, &state);
+    save_state(state_path, &state).map_err(save_error)?;
+    Ok(())
 }
 
 /// Moves a host pack between the host mod's folder and Modrex's disabled area, then flips its
@@ -454,7 +462,7 @@ fn move_host_pack(
     uid: &str,
     cfg: &ModEngineConfig,
     enable: bool,
-) {
+) -> Result<(), String> {
     let active = host_pack_dir(game_path, cfg, &state.mods, &state.folders, m);
     let disabled = host_pack_disabled_dir(game_path, cfg, m);
     if let (Some(active), Some(disabled)) = (active, disabled) {
@@ -477,7 +485,8 @@ fn move_host_pack(
             x.enabled = enable;
         }
     }
-    save_state(state_path, state);
+    save_state(state_path, state).map_err(save_error)?;
+    Ok(())
 }
 
 pub fn disable_mod_op(
@@ -486,21 +495,20 @@ pub fn disable_mod_op(
     uid: &str,
     cfg: &ModEngineConfig,
     launcher: Option<&str>,
-) {
-    let mut state = read_state(state_path);
+) -> Result<(), String> {
+    let mut state = read_state(state_path).map_err(|e| e.to_string())?;
     let Some(m) = state
         .mods
         .iter()
         .find(|m| m.uid == uid && m.enabled)
         .cloned()
     else {
-        return;
+        return Ok(());
     };
     log::info!("disable: {} ({})", m.name, m.uid);
     // Host packs move out of the host mod's folder into our disabled area.
     if is_host_pack(&m) {
-        move_host_pack(game_path, state_path, &mut state, &m, uid, cfg, false);
-        return;
+        return move_host_pack(game_path, state_path, &mut state, &m, uid, cfg, false);
     }
     let target = cfg.target_for(m.location.as_deref());
     if target.enabled_state == Activation::Ue4ssModsTxt {
@@ -511,8 +519,8 @@ pub fn disable_mod_op(
                 m.enabled = false;
             }
         }
-        save_state(state_path, &state);
-        return;
+        save_state(state_path, &state).map_err(save_error)?;
+        return Ok(());
     }
     let rel = get_folder_path(&state.folders, m.folder_id.as_deref());
     let dis_dir = match &rel {
@@ -544,7 +552,8 @@ pub fn disable_mod_op(
             m.enabled = false;
         }
     }
-    save_state(state_path, &state);
+    save_state(state_path, &state).map_err(save_error)?;
+    Ok(())
 }
 
 /// Copies src to dest, plus any companion siblings sharing src's stem, to the matching

--- a/apps/desktop/src-tauri/src/commands/mods/install.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/install.rs
@@ -315,14 +315,19 @@ pub fn move_crimeboss_mod_target_op(
     // install_mod_from_path's own "existing" cleanup computes the old path inside the new
     // target's directory using the old filename, which never matches a cross-target move. The
     // real old location, under the old target's directory, is removed here instead.
-    match &old_target.unit {
+    let removed = match &old_target.unit {
         ModUnit::File { extension, .. } => {
-            let _ = remove_file_with_sidecars(&old_path, extension, old_target.companions);
+            remove_file_with_sidecars(&old_path, extension, old_target.companions)
         }
-        ModUnit::Directory { .. } => {
-            let _ = fs::remove_dir_all(&old_path);
-        }
-    }
+        ModUnit::Directory { .. } => fs::remove_dir_all(&old_path)
+            .map_err(|e| format!("could not remove {}: {e}", log_name(&old_path))),
+    };
+    // The mod now exists under both targets and the game would load it twice, which is the
+    // one outcome this move exists to prevent. Nothing can undo the copy safely at this
+    // point, so say so instead of reporting a clean move.
+    removed.map_err(|e| {
+        format!("the mod was moved but its old copy is still in place, so the game may load it twice: {e}")
+    })?;
 
     Ok(())
 }
@@ -437,7 +442,8 @@ pub fn enable_mod_op(
             ModUnit::File { extension, .. } => {
                 rename_with_sidecars(&from, &to, extension, target.companions)
             }
-            ModUnit::Directory { .. } => fs::rename(&from, &to),
+            ModUnit::Directory { .. } => fs::rename(&from, &to)
+                .map_err(|e| format!("could not move {}: {e}", log_name(&from))),
         };
         if let Err(e) = renamed {
             log::warn!("enable_mod: rename {from:?} -> {to:?}: {e}");
@@ -541,7 +547,8 @@ pub fn disable_mod_op(
             ModUnit::File { extension, .. } => {
                 rename_with_sidecars(&from, &to, extension, target.companions)
             }
-            ModUnit::Directory { .. } => fs::rename(&from, &to),
+            ModUnit::Directory { .. } => fs::rename(&from, &to)
+                .map_err(|e| format!("could not move {}: {e}", log_name(&from))),
         };
         if let Err(e) = renamed {
             log::warn!("disable_mod: rename {from:?} -> {to:?}: {e}");
@@ -556,66 +563,138 @@ pub fn disable_mod_op(
     Ok(())
 }
 
-/// Copies src to dest, plus any companion siblings sharing src's stem, to the matching
-/// siblings of dest. A missing companion is not an error.
+/// Puts back the moves a failed group move already made, most recent first so each
+/// destination is free before the one before it is restored.
+fn undo_moves(moved: &[(std::path::PathBuf, std::path::PathBuf)]) -> Result<(), String> {
+    let problems: Vec<String> = moved
+        .iter()
+        .rev()
+        .filter_map(|(from, to)| match fs::rename(from, to) {
+            Ok(()) => None,
+            Err(e) => Some(format!("{}: {e}", log_name(to))),
+        })
+        .collect();
+    if problems.is_empty() {
+        return Ok(());
+    }
+    Err(problems.join("; "))
+}
+
+/// Copies src to dest, plus any companion sharing src's stem, as one unit.
+///
+/// A missing companion is normal. A companion that fails to copy is not: an Unreal pak
+/// mounts the container its ucas and utoc hold, so a pak installed without them is a mod the
+/// game loads and cannot read. The outputs this call created are removed, leaving a
+/// destination that already existed alone, since undoing an overwrite would need a copy of
+/// what was there.
 fn copy_file_with_sidecars(
     src: &Path,
     dest: &Path,
     main_ext: &str,
     companions: &[&str],
 ) -> Result<(), String> {
-    fs::copy(src, dest).map_err(|e| e.to_string())?;
+    let dest_existed = dest.exists();
+    fs::copy(src, dest).map_err(|e| format!("could not copy {}: {e}", log_name(src)))?;
+    let mut created: Vec<std::path::PathBuf> = Vec::new();
+    if !dest_existed {
+        created.push(dest.to_path_buf());
+    }
     for ext in companions {
         let Some(sidecar) = sidecar_path(src, main_ext, ext) else {
             continue;
         };
-        if sidecar.exists() {
-            if let Some(dest_sidecar) = sidecar_path(dest, main_ext, ext) {
-                let _ = fs::copy(&sidecar, dest_sidecar);
+        if !sidecar.exists() {
+            continue;
+        }
+        let Some(dest_sidecar) = sidecar_path(dest, main_ext, ext) else {
+            continue;
+        };
+        let sidecar_existed = dest_sidecar.exists();
+        if let Err(e) = fs::copy(&sidecar, &dest_sidecar) {
+            let failed = format!("could not copy {}: {e}", log_name(&sidecar));
+            let leftovers: Vec<String> = created
+                .iter()
+                .rev()
+                .filter_map(|p| {
+                    fs::remove_file(p)
+                        .err()
+                        .map(|e| format!("{}: {e}", log_name(p)))
+                })
+                .collect();
+            if leftovers.is_empty() {
+                return Err(failed);
             }
+            return Err(format!(
+                "{failed}; and the partial copy could not be cleaned up: {}",
+                leftovers.join("; ")
+            ));
+        }
+        if !sidecar_existed {
+            created.push(dest_sidecar);
         }
     }
     Ok(())
 }
 
-/// Renames from to to, plus any companion siblings of from to the matching siblings of to.
-/// Used for enable and disable, which move a mod between active and disabled directories.
+/// Renames from to to, plus any companion sharing from's stem, as one unit.
+///
+/// Used by enable and disable, which move a mod between the active and disabled locations. A
+/// companion left behind would split the mod across both, so the moves already made are put
+/// back. The failure is reported either way: a move that had to be undone did not happen.
 fn rename_with_sidecars(
     from: &Path,
     to: &Path,
     main_ext: &str,
     companions: &[&str],
-) -> std::io::Result<()> {
-    fs::rename(from, to)?;
+) -> Result<(), String> {
+    fs::rename(from, to).map_err(|e| format!("could not move {}: {e}", log_name(from)))?;
+    let mut moved = vec![(to.to_path_buf(), from.to_path_buf())];
     for ext in companions {
         let Some(sidecar) = sidecar_path(from, main_ext, ext) else {
             continue;
         };
-        if sidecar.exists() {
-            if let Some(to_sidecar) = sidecar_path(to, main_ext, ext) {
-                let _ = fs::rename(&sidecar, to_sidecar);
-            }
+        if !sidecar.exists() {
+            continue;
         }
+        let Some(to_sidecar) = sidecar_path(to, main_ext, ext) else {
+            continue;
+        };
+        if let Err(e) = fs::rename(&sidecar, &to_sidecar) {
+            let failed = format!("could not move {}: {e}", log_name(&sidecar));
+            return Err(match undo_moves(&moved) {
+                Ok(()) => failed,
+                Err(undo) => format!("{failed}; and putting the mod back failed: {undo}"),
+            });
+        }
+        moved.push((to_sidecar, sidecar));
     }
     Ok(())
 }
 
-/// Removes path, plus any companion siblings sharing its stem.
+/// Removes path, plus any companion sharing its stem.
+///
+/// Deletion has no counterpart to undo it, so a companion that will not go is reported and
+/// the caller decides what that means for the mod's record.
 fn remove_file_with_sidecars(
     path: &Path,
     main_ext: &str,
     companions: &[&str],
-) -> std::io::Result<()> {
-    fs::remove_file(path)?;
-    for ext in companions {
-        let Some(sidecar) = sidecar_path(path, main_ext, ext) else {
-            continue;
-        };
-        if sidecar.exists() {
-            let _ = fs::remove_file(&sidecar);
-        }
+) -> Result<(), String> {
+    fs::remove_file(path).map_err(|e| format!("could not remove {}: {e}", log_name(path)))?;
+    let problems: Vec<String> = companions
+        .iter()
+        .filter_map(|ext| sidecar_path(path, main_ext, ext))
+        .filter(|sidecar| sidecar.exists())
+        .filter_map(|sidecar| {
+            fs::remove_file(&sidecar)
+                .err()
+                .map(|e| format!("{}: {e}", log_name(&sidecar)))
+        })
+        .collect();
+    if problems.is_empty() {
+        return Ok(());
     }
-    Ok(())
+    Err(problems.join("; "))
 }
 
 fn copy_dir_all(src: &Path, dst: &Path) -> Result<(), String> {

--- a/apps/desktop/src-tauri/src/commands/mods/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/mod.rs
@@ -26,6 +26,7 @@ pub use self::engine::{backup_dir, engine_for_game, ModEngineConfig, ModUnit, Sc
 pub use self::identity::IdentityEvidence;
 pub use self::install::install_mod_from_path;
 pub use self::paths::{find_untracked_host_packs, find_untracked_paks, get_state_path, mods_base};
+use self::state::save_error;
 pub use self::state::{get_folder_path, read_state, reconcile_state};
 pub use self::types::{
     InstalledMod, InstalledResponse, ModFolder, ModsState, TopLevelItem, UpdateStatus,
@@ -175,7 +176,7 @@ pub async fn get_installed(app: AppHandle, game_id: String) -> Result<InstalledR
     let state_path = get_state_path(&game_path, cfg);
     let mods_hidden = backup_dir(&game_path, cfg.primary()).exists();
 
-    let mut state = reconcile_state(&game_path, &state_path, cfg);
+    let mut state = reconcile_state(&game_path, &state_path, cfg).map_err(|e| e.to_string())?;
     let any_upgraded = upgrade_negative_ids(&app, &game_path, cfg, &state.folders, &mut state.mods);
     regroup_negative_ids_by_name_suffix(&mut state.mods);
 
@@ -254,7 +255,7 @@ pub async fn get_installed(app: AppHandle, game_id: String) -> Result<InstalledR
             index.as_ref(),
         );
         if any_upgraded || discovered_hosts || cb_resynced || identified {
-            save_state(&state_path, &state);
+            save_state(&state_path, &state).map_err(save_error)?;
         }
         return Ok(InstalledResponse {
             mods: state.mods,
@@ -288,13 +289,15 @@ pub async fn get_installed(app: AppHandle, game_id: String) -> Result<InstalledR
         );
         let (mods, any_checked) = mark_archive_files(&game_path, &state.folders, state.mods, cfg);
         if any_checked || any_upgraded || discovered_hosts || cb_resynced || identified {
-            save_state(
+            if let Err(e) = save_state(
                 &state_path,
                 &ModsState {
                     folders: state.folders.clone(),
                     mods: mods.clone(),
                 },
-            );
+            ) {
+                log::warn!("get_installed: could not persist refreshed identities: {e}");
+            }
         }
         return Ok(InstalledResponse {
             mods,
@@ -327,13 +330,15 @@ pub async fn get_installed(app: AppHandle, game_id: String) -> Result<InstalledR
     let mut mods = mods;
     identity::ensure_identities(&game_path, cfg, &folders, &mut mods, index.as_ref());
     let (mods, _) = mark_archive_files(&game_path, &folders, mods, cfg);
-    save_state(
+    if let Err(e) = save_state(
         &state_path,
         &ModsState {
             folders: folders.clone(),
             mods: mods.clone(),
         },
-    );
+    ) {
+        log::warn!("get_installed: could not persist the scanned state: {e}");
+    }
     Ok(InstalledResponse {
         mods,
         folders,
@@ -443,7 +448,10 @@ pub async fn install_mod(
         // sources::source_native_local_id) and is never compared against this directly.
         let remote_id_str = remote_id.to_string();
         let sp = get_state_path(&game_path, cfg);
-        let saved = read_state(&sp);
+        let saved = read_state(&sp).map_err(|e| {
+            log::warn!("install: {e}");
+            e.to_string()
+        })?;
         let existing_entry = saved.mods.iter().find(|m| m.uid == uid).or_else(|| {
             if remote_id <= 0 {
                 return None;
@@ -494,7 +502,7 @@ pub async fn install_mod(
                 .filter(|m| m.remote_id.as_deref() == Some(remote_id_str.as_str()))
                 .collect();
             if same.len() == 1 {
-                uninstall_mod_op(&game_path, &sp, &same[0].uid.clone(), cfg);
+                uninstall_mod_op(&game_path, &sp, &same[0].uid.clone(), cfg)?;
             }
         }
 
@@ -527,7 +535,7 @@ pub async fn install_mod(
             let settings = read_settings(&app);
             let launcher_str =
                 game_settings(&settings, cfg.game_id).and_then(|gs| gs.launcher.clone());
-            disable_mod_op(&game_path, &sp, &uid, cfg, launcher_str.as_deref());
+            disable_mod_op(&game_path, &sp, &uid, cfg, launcher_str.as_deref())?;
         }
 
         register_download(&app, file_id).await;
@@ -604,7 +612,10 @@ pub async fn install_file(
         let uid = file_id.to_string();
         let mod_id_str = mod_id.to_string();
         let sp = get_state_path(&game_path, cfg);
-        let saved = read_state(&sp);
+        let saved = read_state(&sp).map_err(|e| {
+            log::warn!("install: {e}");
+            e.to_string()
+        })?;
         let existing_entry = saved.mods.iter().find(|m| m.uid == uid).or_else(|| {
             if mod_id <= 0 {
                 return None;
@@ -751,7 +762,10 @@ pub(crate) async fn install_nexus_download(
         let sha256 = staged_content_sha256(target, &tmp).await?;
         let uid = format!("nexus:{nexus_mod_id}:{nexus_file_id}");
         let sp = get_state_path(game_path, cfg);
-        let saved = read_state(&sp);
+        let saved = read_state(&sp).map_err(|e| {
+            log::warn!("install: {e}");
+            e.to_string()
+        })?;
         let existing = saved.mods.iter().find(|m| m.uid == uid);
         let folder_id = existing.and_then(|e| e.folder_id.clone());
         let filename = existing.map(|m| m.filename.clone()).unwrap_or_else(|| {
@@ -1199,7 +1213,10 @@ pub async fn install_from_zip_entry(
         }
         let sha256 = staged_content_sha256(target, &ext).await?;
         let sp = get_state_path(&game_path, cfg);
-        let saved = read_state(&sp);
+        let saved = read_state(&sp).map_err(|e| {
+            log::warn!("install: {e}");
+            e.to_string()
+        })?;
         let mod_id_str = mod_id.to_string();
 
         // Reuse existing uid by SHA256 so a reinstall moves the entry in-place rather than duplicating.
@@ -1213,7 +1230,7 @@ pub async fn install_from_zip_entry(
             stale_entry_for_zip_install(&saved.mods, &uid, mod_id, &mod_id_str, file_id)
         {
             let stale_uid = stale.uid.clone();
-            uninstall_mod_op(&game_path, &sp, &stale_uid, cfg);
+            uninstall_mod_op(&game_path, &sp, &stale_uid, cfg)?;
         }
 
         // Never inherit folderId from existing entries; callers always supply the target folder.
@@ -1304,7 +1321,10 @@ pub async fn install_cb_flat_archive(
             .ok_or_else(|| "mod directory is empty".to_string())?;
         let sha256 = compute_sha256(&hash_path).await?;
         let sp = get_state_path(&game_path, cfg);
-        let saved = read_state(&sp);
+        let saved = read_state(&sp).map_err(|e| {
+            log::warn!("install: {e}");
+            e.to_string()
+        })?;
         let uid = format!("{}_flat", file_id);
         let sha256_match = saved
             .mods
@@ -1474,7 +1494,7 @@ pub async fn uninstall_mod(
 ) -> Result<(), String> {
     let _state_guard = lock_game_state(&app, game_id.as_str()).await;
     let cfg = engine_for_game(game_id.as_str())?;
-    uninstall_mod_op(&game_path, &get_state_path(&game_path, cfg), &uid, cfg);
+    uninstall_mod_op(&game_path, &get_state_path(&game_path, cfg), &uid, cfg)?;
     crate::commands::analytics::track(
         &app,
         "mod_uninstalled",
@@ -1501,7 +1521,7 @@ pub async fn enable_mod(
         &uid,
         cfg,
         launcher.as_deref(),
-    );
+    )?;
     crate::commands::analytics::track(
         &app,
         "mod_enabled",
@@ -1528,7 +1548,7 @@ pub async fn disable_mod(
         &uid,
         cfg,
         launcher.as_deref(),
-    );
+    )?;
     crate::commands::analytics::track(
         &app,
         "mod_disabled",
@@ -1553,7 +1573,7 @@ pub async fn identify_mod_via_nexus_content(
     let _state_guard = lock_game_state(&app, game_id.as_str()).await;
     let cfg = engine_for_game(game_id.as_str())?;
     let state_path = get_state_path(&game_path, cfg);
-    let mut state = read_state(&state_path);
+    let mut state = read_state(&state_path).map_err(|e| e.to_string())?;
 
     let Some(m) = state.mods.iter_mut().find(|m| m.uid == uid) else {
         return Err(format!(
@@ -1573,7 +1593,7 @@ pub async fn identify_mod_via_nexus_content(
     .await?;
 
     if outcome != nexus_content::NexusContentIdentifyOutcome::Skipped {
-        save_state(&state_path, &state);
+        save_state(&state_path, &state).map_err(save_error)?;
     }
     Ok(outcome)
 }
@@ -1623,7 +1643,7 @@ pub async fn reorder_in_folder(
         folder_id.as_deref(),
         &ordered_uids,
         cfg,
-    );
+    )?;
     Ok(())
 }
 
@@ -1646,7 +1666,7 @@ pub async fn move_to_folder(
         target_folder_id,
         target_position,
         cfg,
-    );
+    )?;
     Ok(())
 }
 
@@ -1667,7 +1687,7 @@ pub async fn reorder_children(
         parent_id.as_deref(),
         &items,
         cfg,
-    );
+    )?;
     Ok(())
 }
 
@@ -1688,7 +1708,7 @@ pub async fn move_folder(
         &folder_id,
         target_parent_id,
         cfg,
-    );
+    )?;
     Ok(())
 }
 
@@ -1729,7 +1749,7 @@ pub async fn rename_folder(
         &folder_id,
         &display_name,
         cfg,
-    );
+    )?;
     Ok(())
 }
 
@@ -1748,7 +1768,7 @@ pub async fn delete_folder(
         &get_state_path(&game_path, cfg),
         &folder_id,
         cfg,
-    );
+    )?;
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/src/commands/mods/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/mod.rs
@@ -169,6 +169,7 @@ pub async fn get_installed(app: AppHandle, game_id: String) -> Result<InstalledR
             mods: vec![],
             folders: vec![],
             mods_hidden: false,
+            state_unreadable: false,
         });
     };
 
@@ -176,7 +177,16 @@ pub async fn get_installed(app: AppHandle, game_id: String) -> Result<InstalledR
     let state_path = get_state_path(&game_path, cfg);
     let mods_hidden = backup_dir(&game_path, cfg.primary()).exists();
 
-    let mut state = reconcile_state(&game_path, &state_path, cfg).map_err(|e| e.to_string())?;
+    let (mut state, state_unreadable) = match reconcile_state(&game_path, &state_path, cfg) {
+        Ok(state) => (state, false),
+        // Rebuilding from a scan is useful; writing that rebuild over a file Modrex could not
+        // read would replace the folders, ordering and per-mod metadata only that file holds.
+        // So the scan still runs and every save below is skipped until it loads again.
+        Err(e) => {
+            log::warn!("get_installed: {e}");
+            (ModsState::default(), true)
+        }
+    };
     let any_upgraded = upgrade_negative_ids(&app, &game_path, cfg, &state.folders, &mut state.mods);
     regroup_negative_ids_by_name_suffix(&mut state.mods);
 
@@ -254,13 +264,16 @@ pub async fn get_installed(app: AppHandle, game_id: String) -> Result<InstalledR
             &mut state.mods,
             index.as_ref(),
         );
-        if any_upgraded || discovered_hosts || cb_resynced || identified {
-            save_state(&state_path, &state).map_err(save_error)?;
+        if !state_unreadable && (any_upgraded || discovered_hosts || cb_resynced || identified) {
+            if let Err(e) = save_state(&state_path, &state) {
+                log::warn!("get_installed: could not persist refreshed identities: {e}");
+            }
         }
         return Ok(InstalledResponse {
             mods: state.mods,
             folders: state.folders,
             mods_hidden: true,
+            state_unreadable,
         });
     }
 
@@ -288,7 +301,9 @@ pub async fn get_installed(app: AppHandle, game_id: String) -> Result<InstalledR
             index.as_ref(),
         );
         let (mods, any_checked) = mark_archive_files(&game_path, &state.folders, state.mods, cfg);
-        if any_checked || any_upgraded || discovered_hosts || cb_resynced || identified {
+        if !state_unreadable
+            && (any_checked || any_upgraded || discovered_hosts || cb_resynced || identified)
+        {
             if let Err(e) = save_state(
                 &state_path,
                 &ModsState {
@@ -303,6 +318,7 @@ pub async fn get_installed(app: AppHandle, game_id: String) -> Result<InstalledR
             mods,
             folders: state.folders,
             mods_hidden: false,
+            state_unreadable,
         });
     }
 
@@ -330,19 +346,22 @@ pub async fn get_installed(app: AppHandle, game_id: String) -> Result<InstalledR
     let mut mods = mods;
     identity::ensure_identities(&game_path, cfg, &folders, &mut mods, index.as_ref());
     let (mods, _) = mark_archive_files(&game_path, &folders, mods, cfg);
-    if let Err(e) = save_state(
-        &state_path,
-        &ModsState {
-            folders: folders.clone(),
-            mods: mods.clone(),
-        },
-    ) {
-        log::warn!("get_installed: could not persist the scanned state: {e}");
+    if !state_unreadable {
+        if let Err(e) = save_state(
+            &state_path,
+            &ModsState {
+                folders: folders.clone(),
+                mods: mods.clone(),
+            },
+        ) {
+            log::warn!("get_installed: could not persist the scanned state: {e}");
+        }
     }
     Ok(InstalledResponse {
         mods,
         folders,
         mods_hidden: false,
+        state_unreadable,
     })
 }
 

--- a/apps/desktop/src-tauri/src/commands/mods/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/mod.rs
@@ -27,7 +27,7 @@ pub use self::identity::IdentityEvidence;
 pub use self::install::install_mod_from_path;
 pub use self::paths::{find_untracked_host_packs, find_untracked_paks, get_state_path, mods_base};
 use self::state::save_error;
-pub use self::state::{get_folder_path, read_state, reconcile_state};
+pub use self::state::{get_folder_path, load_for_scan, read_state};
 pub use self::types::{
     InstalledMod, InstalledResponse, ModFolder, ModsState, TopLevelItem, UpdateStatus,
 };
@@ -177,16 +177,7 @@ pub async fn get_installed(app: AppHandle, game_id: String) -> Result<InstalledR
     let state_path = get_state_path(&game_path, cfg);
     let mods_hidden = backup_dir(&game_path, cfg.primary()).exists();
 
-    let (mut state, state_unreadable) = match reconcile_state(&game_path, &state_path, cfg) {
-        Ok(state) => (state, false),
-        // Rebuilding from a scan is useful; writing that rebuild over a file Modrex could not
-        // read would replace the folders, ordering and per-mod metadata only that file holds.
-        // So the scan still runs and every save below is skipped until it loads again.
-        Err(e) => {
-            log::warn!("get_installed: {e}");
-            (ModsState::default(), true)
-        }
-    };
+    let (mut state, writeback) = load_for_scan(&game_path, &state_path, cfg);
     let any_upgraded = upgrade_negative_ids(&app, &game_path, cfg, &state.folders, &mut state.mods);
     regroup_negative_ids_by_name_suffix(&mut state.mods);
 
@@ -264,16 +255,14 @@ pub async fn get_installed(app: AppHandle, game_id: String) -> Result<InstalledR
             &mut state.mods,
             index.as_ref(),
         );
-        if !state_unreadable && (any_upgraded || discovered_hosts || cb_resynced || identified) {
-            if let Err(e) = save_state(&state_path, &state) {
-                log::warn!("get_installed: could not persist refreshed identities: {e}");
-            }
+        if any_upgraded || discovered_hosts || cb_resynced || identified {
+            writeback.save(&state_path, &state, "refreshed identities");
         }
         return Ok(InstalledResponse {
             mods: state.mods,
             folders: state.folders,
             mods_hidden: true,
-            state_unreadable,
+            state_unreadable: writeback.blocked(),
         });
     }
 
@@ -301,24 +290,21 @@ pub async fn get_installed(app: AppHandle, game_id: String) -> Result<InstalledR
             index.as_ref(),
         );
         let (mods, any_checked) = mark_archive_files(&game_path, &state.folders, state.mods, cfg);
-        if !state_unreadable
-            && (any_checked || any_upgraded || discovered_hosts || cb_resynced || identified)
-        {
-            if let Err(e) = save_state(
+        if any_checked || any_upgraded || discovered_hosts || cb_resynced || identified {
+            writeback.save(
                 &state_path,
                 &ModsState {
                     folders: state.folders.clone(),
                     mods: mods.clone(),
                 },
-            ) {
-                log::warn!("get_installed: could not persist refreshed identities: {e}");
-            }
+                "refreshed identities",
+            );
         }
         return Ok(InstalledResponse {
             mods,
             folders: state.folders,
             mods_hidden: false,
-            state_unreadable,
+            state_unreadable: writeback.blocked(),
         });
     }
 
@@ -346,22 +332,19 @@ pub async fn get_installed(app: AppHandle, game_id: String) -> Result<InstalledR
     let mut mods = mods;
     identity::ensure_identities(&game_path, cfg, &folders, &mut mods, index.as_ref());
     let (mods, _) = mark_archive_files(&game_path, &folders, mods, cfg);
-    if !state_unreadable {
-        if let Err(e) = save_state(
-            &state_path,
-            &ModsState {
-                folders: folders.clone(),
-                mods: mods.clone(),
-            },
-        ) {
-            log::warn!("get_installed: could not persist the scanned state: {e}");
-        }
-    }
+    writeback.save(
+        &state_path,
+        &ModsState {
+            folders: folders.clone(),
+            mods: mods.clone(),
+        },
+        "the scanned state",
+    );
     Ok(InstalledResponse {
         mods,
         folders,
         mods_hidden: false,
-        state_unreadable,
+        state_unreadable: writeback.blocked(),
     })
 }
 

--- a/apps/desktop/src-tauri/src/commands/mods/reorder.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/reorder.rs
@@ -2,7 +2,7 @@ use super::engine::ModEngineConfig;
 use super::naming::log_name;
 use super::naming::{apply_priority_prefix, strip_priority_prefix};
 use super::paths::{active_mod_path, disabled_base, disabled_mod_path, mods_base};
-use super::state::{get_folder_path, read_state, save_state};
+use super::state::{get_folder_path, read_state, save_error, save_state};
 use super::types::{InstalledMod, TopLevelItem};
 use std::fs;
 use std::path::Path;
@@ -13,8 +13,8 @@ pub fn reorder_mods_in_folder_op(
     folder_id: Option<&str>,
     ordered_uids: &[String],
     cfg: &ModEngineConfig,
-) {
-    let mut state = read_state(state_path);
+) -> Result<(), String> {
+    let mut state = read_state(state_path).map_err(|e| e.to_string())?;
     let folder_rel = get_folder_path(&state.folders, folder_id);
     let total = ordered_uids.len() as i64;
 
@@ -53,7 +53,8 @@ pub fn reorder_mods_in_folder_op(
         m.priority = Some(priority);
     }
 
-    save_state(state_path, &state);
+    save_state(state_path, &state).map_err(save_error)?;
+    Ok(())
 }
 
 pub fn move_mod_to_folder_op(
@@ -63,13 +64,13 @@ pub fn move_mod_to_folder_op(
     target_folder_id: Option<String>,
     target_position: usize,
     cfg: &ModEngineConfig,
-) {
-    let mut state = read_state(state_path);
+) -> Result<(), String> {
+    let mut state = read_state(state_path).map_err(|e| e.to_string())?;
     let Some(moving) = state.mods.iter().find(|m| m.uid == uid).cloned() else {
-        return;
+        return Ok(());
     };
     if moving.location.is_some() {
-        return;
+        return Ok(());
     }
 
     let src_rel = get_folder_path(&state.folders, moving.folder_id.as_deref());
@@ -141,7 +142,8 @@ pub fn move_mod_to_folder_op(
         m.folder_id = target_folder_id.clone();
     }
 
-    save_state(state_path, &state);
+    save_state(state_path, &state).map_err(save_error)?;
+    Ok(())
 }
 
 pub fn reorder_children_op(
@@ -150,8 +152,8 @@ pub fn reorder_children_op(
     parent_id: Option<&str>,
     items: &[TopLevelItem],
     cfg: &ModEngineConfig,
-) {
-    let mut state = read_state(state_path);
+) -> Result<(), String> {
+    let mut state = read_state(state_path).map_err(|e| e.to_string())?;
     let parent_rel = get_folder_path(&state.folders, parent_id);
     let mods_dir = match &parent_rel {
         Some(r) => mods_base(game_path, cfg.primary()).join(r),
@@ -305,5 +307,6 @@ pub fn reorder_children_op(
         }
     }
 
-    save_state(state_path, &state);
+    save_state(state_path, &state).map_err(save_error)?;
+    Ok(())
 }

--- a/apps/desktop/src-tauri/src/commands/mods/state.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/state.rs
@@ -37,69 +37,113 @@ fn migrate_version_sentinels(m: &mut InstalledMod) {
     m.version = String::new();
 }
 
-pub fn read_state(state_path: &Path) -> ModsState {
-    if !state_path.exists() {
-        return ModsState::default();
-    }
-    let content = fs::read_to_string(state_path).unwrap_or_default();
-    let parsed: serde_json::Value = match serde_json::from_str(&content) {
-        Ok(v) => v,
-        Err(_) => return ModsState::default(),
-    };
-
-    let folders = parsed["folders"]
-        .as_array()
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| serde_json::from_value(v.clone()).ok())
-                .collect()
-        })
-        .unwrap_or_default();
-
-    let mods = parsed["mods"]
-        .as_array()
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| {
-                    let mut m: InstalledMod = serde_json::from_value(v.clone()).ok()?;
-                    if m.uid.is_empty() {
-                        m.uid = make_uid(m.file_id, &m.filename);
-                    }
-                    migrate_version_sentinels(&mut m);
-                    Some(m)
-                })
-                .collect()
-        })
-        .unwrap_or_default();
-
-    ModsState { folders, mods }
+/// Why a state file could not be loaded.
+///
+/// The two cases need opposite handling and must not be collapsed. An unreadable file is
+/// intact and often readable again moments later (a virus scanner or another process holding
+/// it), so nothing may replace it and no recovery copy may be made. Invalid content will not
+/// repair itself, but replacing it with a reconstruction still loses the folders, ordering and
+/// per-mod metadata only that file holds. Either way the file stays exactly where it is.
+///
+/// Messages carry no path: they reach the interface through command errors.
+#[derive(Debug)]
+pub enum StateLoadError {
+    Unreadable(std::io::Error),
+    Invalid(String),
 }
 
-pub fn save_state(state_path: &Path, state: &ModsState) {
-    let Some(parent) = state_path.parent() else {
-        return;
-    };
-    if let Err(e) = fs::create_dir_all(parent) {
-        log::warn!("save_state: create_dir_all {parent:?}: {e}");
-        return;
+impl std::fmt::Display for StateLoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unreadable(e) => write!(f, "the installed-mod list could not be read: {e}"),
+            Self::Invalid(reason) => write!(f, "the installed-mod list is not valid: {reason}"),
+        }
     }
+}
+
+/// Deserializes one declared collection, rejecting the whole load if any element fails.
+///
+/// An absent key stays an empty list because a state file has always been allowed to omit
+/// one. A present key that is not an array, or an element that does not fit the current
+/// schema, invalidates the load: dropping the element instead would silently discard a mod
+/// or a folder and the next save would persist that loss.
+fn read_collection<T: serde::de::DeserializeOwned>(
+    object: &serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Result<Vec<T>, StateLoadError> {
+    let Some(value) = object.get(key) else {
+        return Ok(Vec::new());
+    };
+    let Some(array) = value.as_array() else {
+        return Err(StateLoadError::Invalid(format!("'{key}' is not a list")));
+    };
+    array
+        .iter()
+        .enumerate()
+        .map(|(i, v)| {
+            serde_json::from_value(v.clone()).map_err(|e| {
+                StateLoadError::Invalid(format!("{key} entry {} is not valid: {e}", i + 1))
+            })
+        })
+        .collect()
+}
+
+pub fn read_state(state_path: &Path) -> Result<ModsState, StateLoadError> {
+    // Taken from the read itself rather than a separate exists() check, so a file appearing or
+    // vanishing between the two cannot be mistaken for the other case.
+    let content = match fs::read_to_string(state_path) {
+        Ok(content) => content,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(ModsState::default()),
+        Err(e) => return Err(StateLoadError::Unreadable(e)),
+    };
+    let parsed: serde_json::Value =
+        serde_json::from_str(&content).map_err(|e| StateLoadError::Invalid(e.to_string()))?;
+    let Some(object) = parsed.as_object() else {
+        return Err(StateLoadError::Invalid(
+            "the top level is not a JSON object".to_string(),
+        ));
+    };
+
+    let folders = read_collection(object, "folders")?;
+    let mut mods: Vec<InstalledMod> = read_collection(object, "mods")?;
+    for m in mods.iter_mut() {
+        if m.uid.is_empty() {
+            m.uid = make_uid(m.file_id, &m.filename);
+        }
+        migrate_version_sentinels(m);
+    }
+
+    Ok(ModsState { folders, mods })
+}
+
+/// One wording for a failed persist, so the interface reads the same wherever it surfaces.
+/// Carries no path, for the reason given on StateLoadError.
+pub fn save_error(e: std::io::Error) -> String {
+    format!("the installed-mod list could not be saved: {e}")
+}
+
+pub fn save_state(state_path: &Path, state: &ModsState) -> std::io::Result<()> {
+    let parent = state_path.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "the mod list path has no parent directory",
+        )
+    })?;
+    fs::create_dir_all(parent)?;
+    let body = serde_json::to_string_pretty(state)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
     let mut tmp_name = state_path
         .file_name()
         .unwrap_or_else(|| std::ffi::OsStr::new("state"))
         .to_os_string();
     tmp_name.push(".tmp");
     let tmp = state_path.with_file_name(tmp_name);
-    if let Err(e) = fs::write(
-        &tmp,
-        serde_json::to_string_pretty(state).unwrap_or_default(),
-    ) {
-        log::warn!("save_state: write failed: {e}");
-        return;
-    }
+    fs::write(&tmp, body)?;
     if let Err(e) = fs::rename(&tmp, state_path) {
-        log::warn!("save_state: rename failed: {e}");
         let _ = fs::remove_file(&tmp);
+        return Err(e);
     }
+    Ok(())
 }
 
 fn compact_folder_priorities(
@@ -190,7 +234,11 @@ fn compact_folder_priorities(
     (compacted, any_changed)
 }
 
-pub fn reconcile_state(game_path: &str, state_path: &Path, cfg: &ModEngineConfig) -> ModsState {
+pub fn reconcile_state(
+    game_path: &str,
+    state_path: &Path,
+    cfg: &ModEngineConfig,
+) -> Result<ModsState, StateLoadError> {
     let bak = backup_dir(game_path, cfg.primary());
     if bak.exists() {
         if cfg.primary().is_directory_unit() {
@@ -207,7 +255,7 @@ pub fn reconcile_state(game_path: &str, state_path: &Path, cfg: &ModEngineConfig
         let _ = fs::rename(&legacy, state_path);
     }
 
-    let mut state = read_state(state_path);
+    let mut state = read_state(state_path)?;
 
     // Recover source-native identity for entries written before remote_id existed:
     // their uid already encodes it as {source}:{mod_id}:{file_id} (the nexus install
@@ -431,13 +479,19 @@ pub fn reconcile_state(game_path: &str, state_path: &Path, cfg: &ModEngineConfig
         || identity_migrated
         || identity_id_repaired
     {
-        save_state(
+        // Class C: everything written here is re-derived on the next load, and the folder
+        // renames compact_folder_priorities already performed converge to the same names on
+        // that load. Failing the whole read over a repeatable write would take the installed
+        // list down for a loss that costs nothing.
+        if let Err(e) = save_state(
             state_path,
             &ModsState {
                 folders: final_folders.clone(),
                 mods: reconciled.clone(),
             },
-        );
+        ) {
+            log::warn!("reconcile_state: could not persist the reconciled state: {e}");
+        }
     }
 
     if reconciled.iter().any(|m| m.priority.is_none()) {
@@ -463,21 +517,24 @@ pub fn reconcile_state(game_path: &str, state_path: &Path, cfg: &ModEngineConfig
                 m
             })
             .collect();
-        save_state(
+        // Class C: the priority backfill recomputes identically on the next load.
+        if let Err(e) = save_state(
             state_path,
             &ModsState {
                 folders: final_folders.clone(),
                 mods: migrated.clone(),
             },
-        );
-        return ModsState {
+        ) {
+            log::warn!("reconcile_state: could not persist the priority backfill: {e}");
+        }
+        return Ok(ModsState {
             folders: final_folders,
             mods: migrated,
-        };
+        });
     }
 
-    ModsState {
+    Ok(ModsState {
         folders: final_folders,
         mods: reconciled,
-    }
+    })
 }

--- a/apps/desktop/src-tauri/src/commands/mods/state.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/state.rs
@@ -234,6 +234,50 @@ fn compact_folder_priorities(
     (compacted, any_changed)
 }
 
+/// Permission to write the state file back, held only when it could be read.
+///
+/// A scan can always rebuild a mod list, but writing that rebuild over a file Modrex failed to
+/// read would replace the folders, ordering and per-mod metadata that live only in the file.
+/// Every writeback in get_installed goes through this rather than through a flag each exit has
+/// to remember to check, so a new exit cannot persist a rebuild by omission.
+#[derive(Clone, Copy, Debug)]
+pub struct Writeback(bool);
+
+impl Writeback {
+    /// True when the state was unreadable, which is what get_installed reports to the interface.
+    pub fn blocked(self) -> bool {
+        !self.0
+    }
+
+    /// Saves unless the state this was derived from could not be read.
+    ///
+    /// A failed save is logged and swallowed: the scan result is still correct to show, and the
+    /// next call reaches the same point again.
+    pub fn save(self, state_path: &Path, state: &ModsState, what: &str) {
+        if !self.0 {
+            return;
+        }
+        if let Err(e) = save_state(state_path, state) {
+            log::warn!("get_installed: could not persist {what}: {e}");
+        }
+    }
+}
+
+/// Loads the state a scan starts from, degrading to an empty one that must not be written back.
+pub fn load_for_scan(
+    game_path: &str,
+    state_path: &Path,
+    cfg: &ModEngineConfig,
+) -> (ModsState, Writeback) {
+    match reconcile_state(game_path, state_path, cfg) {
+        Ok(state) => (state, Writeback(true)),
+        Err(e) => {
+            log::warn!("get_installed: {e}");
+            (ModsState::default(), Writeback(false))
+        }
+    }
+}
+
 pub fn reconcile_state(
     game_path: &str,
     state_path: &Path,

--- a/apps/desktop/src-tauri/src/commands/mods/tests.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/tests.rs
@@ -3677,6 +3677,11 @@ fn read_enabled_from_file_none_when_missing_or_malformed() {
     assert_eq!(read_enabled_from_file(&no_enabled_entry), None);
 }
 
+/// USERPROFILE is process-wide and cargo runs tests in parallel, so two tests pointing it at
+/// their own temporary profile would send one of them to the other's ModSettings folder. Every
+/// test that sets it takes this first.
+static USERPROFILE_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 // ── enable after in-game disable (M40 / resync bug) ──────────────────────────
 // resync_crimeboss_enabled_flags sets m.enabled=false without moving files, leaving them at the
 // active path. enable_mod_op must still sync the settings file in that state.
@@ -3719,6 +3724,7 @@ fn enable_mod_op_syncs_settings_when_files_are_at_active_path_but_state_says_dis
     let settings_file = settings_dir.join("m40dallaspd.json");
     fs::write(&settings_file, r#"[{"name":"enabled","value":"false"}]"#).unwrap();
 
+    let _profile = USERPROFILE_GUARD.lock().unwrap_or_else(|e| e.into_inner());
     std::env::set_var("USERPROFILE", profile_tmp.path());
 
     enable_mod_op(game, &sp, "1", cfg, Some("steam")).unwrap();
@@ -3787,6 +3793,7 @@ fn a_duplicated_crimeboss_mod_is_refused_before_the_game_is_switched() {
     let before = r#"[{"name":"enabled","value":"true"},{"name":"volume","value":"0.8"}]"#;
     fs::write(&settings_file, before).unwrap();
 
+    let _profile = USERPROFILE_GUARD.lock().unwrap_or_else(|e| e.into_inner());
     std::env::set_var("USERPROFILE", profile_tmp.path());
     let err = disable_mod_op(game, &sp, "1", cfg, Some("steam")).unwrap_err();
     std::env::remove_var("USERPROFILE");

--- a/apps/desktop/src-tauri/src/commands/mods/tests.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/tests.rs
@@ -4654,3 +4654,547 @@ async fn staged_content_sha256_reports_an_empty_directory() {
         Err("mod directory is empty".to_string())
     );
 }
+
+// ── State load and activation failure paths ───────────────────────────────
+//
+// Every construction below uses the real filesystem. Assertions are on failure and on the
+// resulting disk and state, never on a std::io::ErrorKind: Windows and Linux return
+// different kinds for the same construction (PermissionDenied vs IsADirectory).
+
+use super::state::StateLoadError;
+
+fn state_file_with(body: &[u8]) -> (TempDir, std::path::PathBuf) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join(".modrex.json");
+    fs::write(&path, body).unwrap();
+    (dir, path)
+}
+
+const TWO_MODS: &str = r#"{"folders":[{"id":"f1","diskName":"001_favs","displayName":"Favs","priority":1,"parentId":null}],
+"mods":[{"uid":"a","id":1,"name":"Alpha","version":"1","filename":"a.pak","enabled":true,"installedAt":"t"},
+        {"uid":"b","id":2,"name":"Beta","version":"2","filename":"b.pak","enabled":true,"installedAt":"t"}]}"#;
+
+#[test]
+fn read_state_rejects_invalid_utf8() {
+    let (_dir, path) = state_file_with(&[0x7b, 0xff, 0xfe, 0x7d]);
+    assert!(matches!(
+        read_state(&path),
+        Err(StateLoadError::Unreadable(_) | StateLoadError::Invalid(_))
+    ));
+}
+
+// Indexing a JSON array by a string key yields null, so the old reader saw a state with no
+// mods and no folders here and would have written that emptiness back.
+#[test]
+fn read_state_rejects_a_wrong_top_level_shape() {
+    let (_dir, path) = state_file_with(b"[1,2,3]");
+    assert!(matches!(read_state(&path), Err(StateLoadError::Invalid(_))));
+}
+
+#[test]
+fn read_state_rejects_an_empty_file() {
+    let (_dir, path) = state_file_with(b"");
+    assert!(matches!(read_state(&path), Err(StateLoadError::Invalid(_))));
+}
+
+// A dropped entry is invisible: the interface looks normal with one mod fewer, and the next
+// save makes the loss permanent.
+#[test]
+fn read_state_fails_rather_than_dropping_one_invalid_mod() {
+    let body = TWO_MODS.replace(r#""name":"Beta","#, "");
+    let (_dir, path) = state_file_with(body.as_bytes());
+    assert!(matches!(read_state(&path), Err(StateLoadError::Invalid(_))));
+}
+
+#[test]
+fn read_state_fails_rather_than_dropping_one_invalid_folder() {
+    let body = TWO_MODS.replace(r#""displayName":"Favs","#, "");
+    let (_dir, path) = state_file_with(body.as_bytes());
+    assert!(matches!(read_state(&path), Err(StateLoadError::Invalid(_))));
+}
+
+// A newer release adding a field must not make its files unreadable by an older one.
+#[test]
+fn read_state_still_accepts_unknown_future_fields() {
+    let body = TWO_MODS.replace(r#""uid":"b","#, r#""uid":"b","futureField":{"x":1},"#);
+    let (_dir, path) = state_file_with(body.as_bytes());
+    let state = read_state(&path).unwrap();
+    assert_eq!(state.mods.len(), 2);
+    assert_eq!(state.folders.len(), 1);
+}
+
+/// The guarantee behind all of this: whatever the operation, an unreadable file comes out
+/// byte for byte as it went in, and nothing new appears beside it.
+fn assert_untouched(path: &std::path::Path, before: &[u8]) {
+    assert_eq!(
+        fs::read(path).unwrap(),
+        before,
+        "the state file must come out byte-identical"
+    );
+    let siblings: Vec<String> = fs::read_dir(path.parent().unwrap())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| n != ".modrex.json")
+        .collect();
+    assert!(
+        siblings.is_empty(),
+        "no recovery or temporary file may be left behind, found {siblings:?}"
+    );
+}
+
+#[test]
+fn an_unreadable_state_file_is_not_overwritten_by_an_install() {
+    let tmp = TempDir::new().unwrap();
+    let game = tmp.path().to_str().unwrap();
+    let cfg = engine_for_game("cb").unwrap();
+    let sp = get_state_path(game, cfg);
+    fs::create_dir_all(sp.parent().unwrap()).unwrap();
+    fs::write(&sp, b"{ not json").unwrap();
+    let before = fs::read(&sp).unwrap();
+    let (_src, pak) = iostore_mod_source();
+
+    let err = install_mod_from_path(
+        game,
+        &sp,
+        iostore_mod_data(),
+        &pak,
+        None,
+        cfg,
+        cfg.target_for(Some("paks")),
+    )
+    .unwrap_err();
+
+    assert!(!err.is_empty());
+    assert_untouched(&sp, &before);
+    // The copy must not have run either: nothing may touch the game folder on a load failure.
+    assert!(
+        !tmp.path().join("CrimeBoss/Content/Paks/~mods").exists(),
+        "no mod files may be written before the state is known to be loadable"
+    );
+}
+
+#[test]
+fn an_unreadable_state_file_is_not_overwritten_by_creating_a_folder() {
+    let tmp = TempDir::new().unwrap();
+    let game = tmp.path().to_str().unwrap();
+    let cfg = engine_for_game("pd2").unwrap();
+    let sp = get_state_path(game, cfg);
+    fs::create_dir_all(sp.parent().unwrap()).unwrap();
+    fs::write(&sp, b"{ not json").unwrap();
+    let before = fs::read(&sp).unwrap();
+
+    assert!(create_folder_op(game, &sp, "New Folder", None, cfg).is_err());
+    assert_untouched(&sp, &before);
+}
+
+// The reorder ops held nothing back before: with an empty state they wrote that emptiness
+// over the file, erasing every record with nothing left to rebuild from.
+#[test]
+fn an_unreadable_state_file_is_not_overwritten_by_a_reorder() {
+    let tmp = TempDir::new().unwrap();
+    let game = tmp.path().to_str().unwrap();
+    let cfg = engine_for_game("pd2").unwrap();
+    let sp = get_state_path(game, cfg);
+    fs::create_dir_all(sp.parent().unwrap()).unwrap();
+    fs::write(&sp, b"{ not json").unwrap();
+    let before = fs::read(&sp).unwrap();
+
+    assert!(reorder_mods_in_folder_op(game, &sp, None, &["a".into()], cfg).is_err());
+    assert_untouched(&sp, &before);
+}
+
+#[test]
+fn an_unreadable_state_file_is_not_overwritten_by_a_toggle() {
+    let tmp = TempDir::new().unwrap();
+    let game = tmp.path().to_str().unwrap();
+    let cfg = engine_for_game("cb").unwrap();
+    let sp = get_state_path(game, cfg);
+    fs::create_dir_all(sp.parent().unwrap()).unwrap();
+    fs::write(&sp, b"{ not json").unwrap();
+    let before = fs::read(&sp).unwrap();
+
+    assert!(disable_mod_op(game, &sp, "1", cfg, None).is_err());
+    assert!(enable_mod_op(game, &sp, "1", cfg, None).is_err());
+    assert_untouched(&sp, &before);
+}
+
+// A locked file is intact and reads again as soon as the handle goes, so treating it as
+// corruption would throw away a perfectly good mod list. Windows is where a sharing denial
+// is reproducible: Unix lets a process read a file another one holds open.
+#[cfg(windows)]
+#[test]
+fn a_locked_state_file_is_left_alone_and_reads_again_once_released() {
+    use std::os::windows::fs::OpenOptionsExt;
+    let (_dir, path) = state_file_with(TWO_MODS.as_bytes());
+    let before = fs::read(&path).unwrap();
+
+    {
+        let _held = fs::OpenOptions::new()
+            .read(true)
+            .share_mode(0)
+            .open(&path)
+            .unwrap();
+        assert!(matches!(
+            read_state(&path),
+            Err(StateLoadError::Unreadable(_))
+        ));
+    }
+
+    assert_untouched(&path, &before);
+    assert_eq!(read_state(&path).unwrap().mods.len(), 2);
+}
+
+// ── Activation transitions ────────────────────────────────────────────────
+
+/// A PAYDAY 3 pak install with its iostore companions, ready to toggle. PD3 rather than
+/// Crime Boss because Crime Boss reads activation from the game's own settings file, so its
+/// toggles deliberately tolerate files that are not where Modrex expects.
+fn installed_pak_fixture() -> (TempDir, std::path::PathBuf, &'static ModEngineConfig) {
+    let tmp = TempDir::new().unwrap();
+    let cfg = engine_for_game("pd3").unwrap();
+    let game = tmp.path().to_str().unwrap().to_string();
+    let sp = get_state_path(&game, cfg);
+    let (_src, pak) = iostore_mod_source();
+    install_mod_from_path(
+        &game,
+        &sp,
+        iostore_mod_data(),
+        &pak,
+        None,
+        cfg,
+        cfg.primary(),
+    )
+    .unwrap();
+    (tmp, sp, cfg)
+}
+
+fn paks_dir(tmp: &TempDir) -> std::path::PathBuf {
+    tmp.path().join("PAYDAY3/Content/Paks/~mods")
+}
+
+/// The disabled name a companion takes, which is not the active name with a suffix appended:
+/// the extension is swapped inside the name and the disabled suffix stays last.
+fn disabled_companion(filename: &str, ext: &str) -> String {
+    format!("{}.{ext}.disabled", filename.trim_end_matches(".pak"))
+}
+
+#[test]
+fn disable_reports_a_blocked_destination_and_changes_nothing() {
+    let (tmp, sp, cfg) = installed_pak_fixture();
+    let filename = read_state(&sp).unwrap().mods[0].filename.clone();
+    // A directory standing where the disabled pak belongs; renaming onto it fails on both
+    // platforms, whereas an empty directory destination does not.
+    let blocker = paks_dir(&tmp)
+        .join("disabled")
+        .join(format!("{filename}.disabled"));
+    fs::create_dir_all(&blocker).unwrap();
+    fs::write(blocker.join("occupied"), b"x").unwrap();
+
+    let err = disable_mod_op(tmp.path().to_str().unwrap(), &sp, "1", cfg, None).unwrap_err();
+
+    assert!(err.contains("could not move"), "unexpected message: {err}");
+    assert!(
+        paks_dir(&tmp).join(&filename).is_file(),
+        "the pak must stay put"
+    );
+    assert!(
+        read_state(&sp).unwrap().mods[0].enabled,
+        "a move that did not happen must not be recorded"
+    );
+}
+
+#[test]
+fn enable_reports_a_blocked_destination_and_changes_nothing() {
+    let (tmp, sp, cfg) = installed_pak_fixture();
+    let game = tmp.path().to_str().unwrap().to_string();
+    disable_mod_op(&game, &sp, "1", cfg, None).unwrap();
+    let filename = read_state(&sp).unwrap().mods[0].filename.clone();
+
+    let blocker = paks_dir(&tmp).join(&filename);
+    fs::create_dir_all(&blocker).unwrap();
+    fs::write(blocker.join("occupied"), b"x").unwrap();
+
+    let err = enable_mod_op(&game, &sp, "1", cfg, None).unwrap_err();
+
+    assert!(err.contains("could not move"), "unexpected message: {err}");
+    assert!(!read_state(&sp).unwrap().mods[0].enabled);
+}
+
+// A directory sitting where the pak belongs is exactly what a blocked move leaves behind.
+// Reading the path as occupied would report the mod as active when it is not.
+#[test]
+fn a_directory_standing_in_for_the_mod_is_not_read_as_the_mod() {
+    let (tmp, sp, cfg) = installed_pak_fixture();
+    let game = tmp.path().to_str().unwrap().to_string();
+    disable_mod_op(&game, &sp, "1", cfg, None).unwrap();
+    let filename = read_state(&sp).unwrap().mods[0].filename.clone();
+    fs::create_dir_all(paks_dir(&tmp).join(&filename)).unwrap();
+
+    let err = enable_mod_op(&game, &sp, "1", cfg, None).unwrap_err();
+
+    // Had the check been a bare exists(), both locations would have looked occupied and this
+    // would have been reported as a duplicate instead of an attempted move.
+    assert!(
+        err.contains("could not move"),
+        "the blocking directory was mistaken for the mod: {err}"
+    );
+}
+
+#[test]
+fn a_mod_present_in_both_locations_is_reported_rather_than_guessed() {
+    let (tmp, sp, cfg) = installed_pak_fixture();
+    let filename = read_state(&sp).unwrap().mods[0].filename.clone();
+    let disabled = paks_dir(&tmp).join("disabled");
+    fs::create_dir_all(&disabled).unwrap();
+    fs::write(disabled.join(format!("{filename}.disabled")), b"pak header").unwrap();
+
+    let err = disable_mod_op(tmp.path().to_str().unwrap(), &sp, "1", cfg, None).unwrap_err();
+
+    assert!(err.contains("both"), "unexpected message: {err}");
+    assert!(read_state(&sp).unwrap().mods[0].enabled);
+}
+
+#[test]
+fn a_mod_that_is_no_longer_on_disk_is_reported() {
+    let (tmp, sp, cfg) = installed_pak_fixture();
+    let filename = read_state(&sp).unwrap().mods[0].filename.clone();
+    fs::remove_file(paks_dir(&tmp).join(&filename)).unwrap();
+
+    let err = disable_mod_op(tmp.path().to_str().unwrap(), &sp, "1", cfg, None).unwrap_err();
+
+    assert!(err.contains("no longer"), "unexpected message: {err}");
+    assert!(read_state(&sp).unwrap().mods[0].enabled);
+}
+
+// A pak that arrives without the container its ucas and utoc hold is a mod the game mounts
+// and cannot read, so the group goes back rather than landing half-moved.
+#[test]
+fn a_companion_that_cannot_move_puts_the_whole_group_back() {
+    let (tmp, sp, cfg) = installed_pak_fixture();
+    let filename = read_state(&sp).unwrap().mods[0].filename.clone();
+    let stem = std::path::Path::new(&filename)
+        .file_stem()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+    let disabled = paks_dir(&tmp).join("disabled");
+    fs::create_dir_all(&disabled).unwrap();
+    let blocker = disabled.join(disabled_companion(&filename, "ucas"));
+    fs::create_dir_all(&blocker).unwrap();
+    fs::write(blocker.join("occupied"), b"x").unwrap();
+
+    let err = disable_mod_op(tmp.path().to_str().unwrap(), &sp, "1", cfg, None).unwrap_err();
+
+    assert!(err.contains("could not move"), "unexpected message: {err}");
+    let active = paks_dir(&tmp);
+    assert!(active.join(&filename).is_file(), "the pak must be back");
+    assert!(
+        active.join(format!("{stem}.utoc")).is_file(),
+        "the utoc must be back"
+    );
+    assert!(
+        active.join(format!("{stem}.ucas")).is_file(),
+        "the ucas never moved"
+    );
+    assert!(read_state(&sp).unwrap().mods[0].enabled);
+}
+
+// The record cannot describe a layout it was never written to, and the scan reads a mod as
+// known wherever it sits, so the files go back rather than drifting out of step silently.
+#[test]
+fn a_failed_save_after_a_successful_move_puts_the_files_back() {
+    let (tmp, sp, cfg) = installed_pak_fixture();
+    let filename = read_state(&sp).unwrap().mods[0].filename.clone();
+    let before = fs::read(&sp).unwrap();
+    // save_state writes its temporary file first; a directory in that name's place fails the
+    // write on both platforms while leaving the real file readable.
+    let mut tmp_name = sp.file_name().unwrap().to_os_string();
+    tmp_name.push(".tmp");
+    fs::create_dir_all(sp.with_file_name(tmp_name)).unwrap();
+
+    let err = disable_mod_op(tmp.path().to_str().unwrap(), &sp, "1", cfg, None).unwrap_err();
+
+    assert!(
+        err.contains("could not be saved"),
+        "unexpected message: {err}"
+    );
+    assert!(
+        paks_dir(&tmp).join(&filename).is_file(),
+        "the pak must be back at the active location"
+    );
+    assert_eq!(
+        fs::read(&sp).unwrap(),
+        before,
+        "a complete reversal needs no second write, so the file is untouched"
+    );
+    assert!(read_state(&sp).unwrap().mods[0].enabled);
+}
+
+// The record already said what the disk now shows, so this corrects the record and moves
+// nothing. It is what makes a toggle interrupted between the move and the save recoverable
+// by repeating it.
+#[test]
+fn a_mod_already_at_the_destination_only_has_its_record_corrected() {
+    let (tmp, sp, cfg) = installed_pak_fixture();
+    let game = tmp.path().to_str().unwrap().to_string();
+    disable_mod_op(&game, &sp, "1", cfg, None).unwrap();
+    let mut state = read_state(&sp).unwrap();
+    state.mods[0].enabled = true;
+    save_state(&sp, &state).unwrap();
+
+    disable_mod_op(&game, &sp, "1", cfg, None).unwrap();
+
+    assert!(!read_state(&sp).unwrap().mods[0].enabled);
+}
+
+#[test]
+fn a_mod_with_no_companions_still_toggles() {
+    let tmp = TempDir::new().unwrap();
+    let game = tmp.path().to_str().unwrap().to_string();
+    let cfg = engine_for_game("cb").unwrap();
+    let sp = get_state_path(&game, cfg);
+    let src = TempDir::new().unwrap();
+    let pak = src.path().join("Bare.pak");
+    fs::write(&pak, b"pak header").unwrap();
+    install_mod_from_path(
+        &game,
+        &sp,
+        InstalledMod {
+            filename: "Bare.pak".into(),
+            ..iostore_mod_data()
+        },
+        &pak,
+        None,
+        cfg,
+        cfg.target_for(Some("paks")),
+    )
+    .unwrap();
+
+    disable_mod_op(&game, &sp, "1", cfg, None).unwrap();
+    assert!(!read_state(&sp).unwrap().mods[0].enabled);
+    enable_mod_op(&game, &sp, "1", cfg, None).unwrap();
+    assert!(read_state(&sp).unwrap().mods[0].enabled);
+}
+
+/// A directory unit is a folder in both locations, so a folder standing at the destination is
+/// indistinguishable from the mod already being there. Saying so beats picking one.
+#[test]
+fn a_directory_unit_in_both_locations_is_reported() {
+    let (tmp, game, sp, cfg) = installed_dir_fixture();
+    let blocker = tmp.path().join("mods/disabled/DirMod");
+    fs::create_dir_all(&blocker).unwrap();
+    fs::write(blocker.join("occupied"), b"x").unwrap();
+
+    let err = disable_mod_op(&game, &sp, "1", cfg, None).unwrap_err();
+
+    assert!(err.contains("both"), "unexpected message: {err}");
+    assert!(tmp.path().join("mods/DirMod/mod.txt").is_file());
+    assert!(read_state(&sp).unwrap().mods[0].enabled);
+}
+
+/// The whole-folder move has the same reversal as a file group: the record could not be
+/// written, so the folder goes back where it was.
+#[test]
+fn a_directory_unit_move_is_put_back_when_the_save_fails() {
+    let (tmp, game, sp, cfg) = installed_dir_fixture();
+    let before = fs::read(&sp).unwrap();
+    let mut tmp_name = sp.file_name().unwrap().to_os_string();
+    tmp_name.push(".tmp");
+    fs::create_dir_all(sp.with_file_name(tmp_name)).unwrap();
+
+    let err = disable_mod_op(&game, &sp, "1", cfg, None).unwrap_err();
+
+    assert!(
+        err.contains("could not be saved"),
+        "unexpected message: {err}"
+    );
+    assert!(
+        tmp.path().join("mods/DirMod/mod.txt").is_file(),
+        "the folder must be back at the active location"
+    );
+    assert!(!tmp.path().join("mods/disabled/DirMod").exists());
+    assert_eq!(fs::read(&sp).unwrap(), before);
+    assert!(read_state(&sp).unwrap().mods[0].enabled);
+}
+
+/// A PAYDAY 2 mod folder install, the directory-unit shape.
+fn installed_dir_fixture() -> (
+    TempDir,
+    String,
+    std::path::PathBuf,
+    &'static ModEngineConfig,
+) {
+    let tmp = TempDir::new().unwrap();
+    let game = tmp.path().to_str().unwrap().to_string();
+    let cfg = engine_for_game("pd2").unwrap();
+    let sp = get_state_path(&game, cfg);
+    let src = TempDir::new().unwrap();
+    fs::write(src.path().join("mod.txt"), b"{}").unwrap();
+    install_mod_from_path(
+        &game,
+        &sp,
+        InstalledMod {
+            uid: "1".into(),
+            id: 1,
+            name: "Dir Mod".into(),
+            filename: "DirMod".into(),
+            enabled: true,
+            ..InstalledMod::default()
+        },
+        src.path(),
+        None,
+        cfg,
+        cfg.primary(),
+    )
+    .unwrap();
+    (tmp, game, sp, cfg)
+}
+
+// ── Sidecar copy and remove ───────────────────────────────────────────────
+
+#[test]
+fn a_failed_companion_copy_removes_only_what_that_attempt_created() {
+    let dir = TempDir::new().unwrap();
+    let (_src, pak) = iostore_mod_source();
+    let dest = dir.path().join("TestMod.pak");
+    // The ucas destination cannot be written, so the copy of the pak beside it must not be
+    // left behind reported as a complete mod.
+    fs::create_dir_all(dir.path().join("TestMod.ucas")).unwrap();
+
+    let err =
+        super::install::copy_file_with_sidecars(&pak, &dest, "pak", &["ucas", "utoc"]).unwrap_err();
+
+    assert!(err.contains("could not copy"), "unexpected message: {err}");
+    assert!(!dest.exists(), "the partial copy must be cleaned up");
+}
+
+// Nothing puts a deleted file back, so a companion that will not go is reported rather than
+// dressed up as a reversible failure.
+#[test]
+fn a_failed_companion_removal_is_reported() {
+    let dir = TempDir::new().unwrap();
+    let pak = dir.path().join("TestMod.pak");
+    fs::write(&pak, b"pak").unwrap();
+    let stuck = dir.path().join("TestMod.ucas");
+    fs::create_dir_all(&stuck).unwrap();
+    fs::write(stuck.join("occupied"), b"x").unwrap();
+
+    let err = super::install::remove_file_with_sidecars(&pak, "pak", &["ucas"]).unwrap_err();
+
+    assert!(err.contains("TestMod.ucas"), "unexpected message: {err}");
+    assert!(!pak.exists(), "the primary was removed and stays removed");
+}
+
+#[test]
+fn a_missing_optional_companion_is_not_a_failure() {
+    let dir = TempDir::new().unwrap();
+    let pak = dir.path().join("TestMod.pak");
+    fs::write(&pak, b"pak").unwrap();
+    let dest = dir.path().join("moved.pak");
+
+    super::install::rename_with_sidecars(&pak, &dest, "pak", &["ucas", "utoc"]).unwrap();
+
+    assert!(dest.is_file());
+}

--- a/apps/desktop/src-tauri/src/commands/mods/tests.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/tests.rs
@@ -798,17 +798,21 @@ fn folder_path_two_levels_nested() {
 #[test]
 fn read_state_missing_file_returns_default() {
     let path = std::path::Path::new("/nonexistent/path/.pd3mm.json");
-    let state = read_state(path);
+    let state = read_state(path).unwrap();
     assert!(state.mods.is_empty());
     assert!(state.folders.is_empty());
 }
 
+// A default state here would be indistinguishable from an empty one, and the next save
+// would write that emptiness over the file the user still has.
 #[test]
-fn read_state_invalid_json_returns_default() {
+fn read_state_invalid_json_is_an_error_rather_than_a_default() {
     let mut f = NamedTempFile::new().unwrap();
     write!(f, "not valid json").unwrap();
-    let state = read_state(f.path());
-    assert!(state.mods.is_empty());
+    assert!(matches!(
+        read_state(f.path()),
+        Err(super::state::StateLoadError::Invalid(_))
+    ));
 }
 
 #[test]
@@ -827,7 +831,7 @@ fn read_state_valid_json_round_trips() {
     }"#;
     let mut f = NamedTempFile::new().unwrap();
     write!(f, "{}", json).unwrap();
-    let state = read_state(f.path());
+    let state = read_state(f.path()).unwrap();
     assert_eq!(state.mods.len(), 1);
     assert_eq!(state.mods[0].uid, "42");
     assert_eq!(state.mods[0].name, "Test Mod");
@@ -850,7 +854,7 @@ fn read_state_missing_uid_synthesized_from_file_id() {
     }"#;
     let mut f = NamedTempFile::new().unwrap();
     write!(f, "{}", json).unwrap();
-    let state = read_state(f.path());
+    let state = read_state(f.path()).unwrap();
     assert_eq!(state.mods[0].uid, "55");
 }
 
@@ -869,7 +873,7 @@ fn read_state_missing_uid_and_file_id_uses_stripped_filename() {
     }"#;
     let mut f = NamedTempFile::new().unwrap();
     write!(f, "{}", json).unwrap();
-    let state = read_state(f.path());
+    let state = read_state(f.path()).unwrap();
     assert_eq!(state.mods[0].uid, "Test_Mod.pak");
 }
 
@@ -886,7 +890,7 @@ fn read_state_missing_parent_id_defaults_to_none() {
     }"#;
     let mut f = NamedTempFile::new().unwrap();
     write!(f, "{}", json).unwrap();
-    let state = read_state(f.path());
+    let state = read_state(f.path()).unwrap();
     assert_eq!(state.folders[0].parent_id, None);
 }
 
@@ -909,7 +913,7 @@ fn read_state_location_field_round_trips() {
     }"#;
     let mut f = NamedTempFile::new().unwrap();
     write!(f, "{}", json).unwrap();
-    let state = read_state(f.path());
+    let state = read_state(f.path()).unwrap();
     assert_eq!(state.mods[0].location.as_deref(), Some("mod_overrides"));
 }
 
@@ -929,7 +933,7 @@ fn read_state_missing_location_is_none() {
     }"#;
     let mut f = NamedTempFile::new().unwrap();
     write!(f, "{}", json).unwrap();
-    let state = read_state(f.path());
+    let state = read_state(f.path()).unwrap();
     assert_eq!(state.mods[0].location, None);
 }
 
@@ -951,7 +955,7 @@ fn read_state_without_nexus_content_missed_still_deserializes() {
     }"#;
     let mut f = NamedTempFile::new().unwrap();
     write!(f, "{}", json).unwrap();
-    let state = read_state(f.path());
+    let state = read_state(f.path()).unwrap();
     assert_eq!(state.mods[0].nexus_content_missed, None);
 }
 
@@ -974,9 +978,10 @@ fn nexus_content_missed_survives_a_save_and_read_round_trip() {
             mods,
             folders: vec![],
         },
-    );
+    )
+    .unwrap();
 
-    let state = read_state(&state_path);
+    let state = read_state(&state_path).unwrap();
     assert_eq!(state.mods[0].nexus_content_missed, Some(true));
 }
 
@@ -1010,11 +1015,12 @@ fn uninstall_mod_keeps_empty_folder() {
                 ..InstalledMod::default()
             }],
         },
-    );
+    )
+    .unwrap();
 
-    uninstall_mod_op(game, &state_path, "mod1", cfg);
+    uninstall_mod_op(game, &state_path, "mod1", cfg).unwrap();
 
-    let state = read_state(&state_path);
+    let state = read_state(&state_path).unwrap();
     assert!(state.mods.is_empty());
     assert_eq!(state.folders.len(), 1);
     assert_eq!(state.folders[0].id, "f1");
@@ -1032,7 +1038,7 @@ fn create_folder_reuses_existing_same_name_sibling() {
     let second = create_folder_op(game, &state_path, "ImprovedRogue", None, cfg).unwrap();
 
     assert_eq!(first.id, second.id);
-    let state = read_state(&state_path);
+    let state = read_state(&state_path).unwrap();
     assert_eq!(state.folders.len(), 1);
 }
 
@@ -1333,9 +1339,10 @@ fn reconcile_state_purges_already_tracked_bundled_ue4ss_submods() {
             folders: vec![],
             mods: vec![stale_entry("ActorDumperMod"), stale_entry("CoolMod")],
         },
-    );
+    )
+    .unwrap();
 
-    let state = reconcile_state(game, &sp, cfg);
+    let state = reconcile_state(game, &sp, cfg).unwrap();
     let names: Vec<&str> = state.mods.iter().map(|m| m.filename.as_str()).collect();
     assert_eq!(names, vec!["CoolMod"]);
 }
@@ -1374,9 +1381,10 @@ fn reconcile_state_recovers_source_identity_from_uid() {
             folders: vec![],
             mods: vec![nexus_entry, workshop_entry],
         },
-    );
+    )
+    .unwrap();
 
-    let state = reconcile_state(game, &sp, cfg);
+    let state = reconcile_state(game, &sp, cfg).unwrap();
     let nexus = state.mods.iter().find(|m| m.source == "nexus").unwrap();
     assert_eq!(nexus.remote_id.as_deref(), Some("123"));
     assert_eq!(nexus.file_remote_id.as_deref(), Some("456"));
@@ -1388,7 +1396,7 @@ fn reconcile_state_recovers_source_identity_from_uid() {
     assert_eq!(workshop.file_remote_id, None);
 
     // Persisted, so the parse never needs to run for these entries again.
-    let saved = read_state(&sp);
+    let saved = read_state(&sp).unwrap();
     let nexus = saved.mods.iter().find(|m| m.source == "nexus").unwrap();
     assert_eq!(nexus.remote_id.as_deref(), Some("123"));
     assert_eq!(nexus.file_remote_id.as_deref(), Some("456"));
@@ -1418,9 +1426,10 @@ fn reconcile_state_leaves_unparsable_source_uid_alone() {
             folders: vec![],
             mods: vec![entry],
         },
-    );
+    )
+    .unwrap();
 
-    let state = reconcile_state(game, &sp, cfg);
+    let state = reconcile_state(game, &sp, cfg).unwrap();
     assert_eq!(state.mods[0].remote_id, None);
     assert_eq!(state.mods[0].file_remote_id, None);
 }
@@ -1455,9 +1464,10 @@ fn reconcile_state_backfills_remote_id_for_a_legacy_modworkshop_entry_without_to
             folders: vec![],
             mods: vec![legacy],
         },
-    );
+    )
+    .unwrap();
 
-    let mut state = reconcile_state(game, &sp, cfg);
+    let mut state = reconcile_state(game, &sp, cfg).unwrap();
     let expected_id = crate::commands::sources::source_native_local_id("modworkshop", "58065");
     assert_eq!(state.mods[0].remote_id.as_deref(), Some("58065"));
     assert_eq!(state.mods[0].id, expected_id);
@@ -1513,14 +1523,15 @@ fn reconcile_state_repairs_a_source_native_id_wrongly_promoted_to_modworkshop() 
             folders: vec![],
             mods: vec![corrupted],
         },
-    );
+    )
+    .unwrap();
 
-    let state = reconcile_state(game, &sp, cfg);
+    let state = reconcile_state(game, &sp, cfg).unwrap();
     assert_eq!(state.mods[0].id, expected_id);
     assert_eq!(state.mods[0].name, "RinoHud", "only id is repaired");
 
     // Persisted, so the repair never needs to run again for this entry.
-    let saved = read_state(&sp);
+    let saved = read_state(&sp).unwrap();
     assert_eq!(saved.mods[0].id, expected_id);
 }
 
@@ -1549,9 +1560,10 @@ fn reconcile_state_leaves_a_correct_source_native_id_alone() {
             folders: vec![],
             mods: vec![entry],
         },
-    );
+    )
+    .unwrap();
 
-    let state = reconcile_state(game, &sp, cfg);
+    let state = reconcile_state(game, &sp, cfg).unwrap();
     assert_eq!(state.mods[0].id, expected_id);
 }
 
@@ -1703,7 +1715,7 @@ fn an_install_records_its_own_provenance() {
 
     install_mod_from_path(game, &sp, mod_data, &src, None, cfg, cfg.primary()).unwrap();
 
-    let saved = read_state(&sp).mods.into_iter().next().unwrap();
+    let saved = read_state(&sp).unwrap().mods.into_iter().next().unwrap();
     assert_eq!(saved.source, "modworkshop");
     assert_eq!(saved.remote_id.as_deref(), Some("25629"));
     assert_eq!(
@@ -1901,7 +1913,8 @@ fn host_fixture() -> (TempDir, std::path::PathBuf, NamedTempFile) {
                 ..InstalledMod::default()
             }],
         },
-    );
+    )
+    .unwrap();
     let zip = make_zip(&[
         ("My Set/standard.png", b"a"),
         ("My Set/crimenet.png", b"b"),
@@ -1936,6 +1949,7 @@ fn install_host_pack_op_places_set_and_records() {
         .exists());
     // Recorded with a host location.
     let rec = read_state(&sp)
+        .unwrap()
         .mods
         .into_iter()
         .find(|m| m.name == "BG Mod")
@@ -1963,7 +1977,7 @@ fn reconcile_keeps_installed_host_pack() {
     let cfg = engine_for_game("pd2").unwrap();
     install_host_pack_op(game, &sp, zip.path(), "My Set", bg_mod_data(), cfg).unwrap();
 
-    let state = reconcile_state(game, &sp, cfg);
+    let state = reconcile_state(game, &sp, cfg).unwrap();
     let rec = state.mods.iter().find(|m| m.name == "BG Mod").unwrap();
     assert_eq!(
         rec.missing, None,
@@ -1978,13 +1992,13 @@ fn uninstall_removes_host_pack() {
     let cfg = engine_for_game("pd2").unwrap();
     install_host_pack_op(game, &sp, zip.path(), "My Set", bg_mod_data(), cfg).unwrap();
 
-    uninstall_mod_op(game, &sp, "999_My Set", cfg);
+    uninstall_mod_op(game, &sp, "999_My Set", cfg).unwrap();
 
     assert!(!tmp
         .path()
         .join("mods/Menu Backgrounds/Assets/My Set")
         .exists());
-    assert!(read_state(&sp).mods.iter().all(|m| m.id != 57135));
+    assert!(read_state(&sp).unwrap().mods.iter().all(|m| m.id != 57135));
 }
 
 fn host_only_entry() -> InstalledMod {
@@ -2081,13 +2095,14 @@ fn disable_then_enable_host_pack_moves_files() {
     let disabled = tmp.path().join("mods/disabled/host-17160/My Set");
     assert!(active.exists() && !disabled.exists());
 
-    disable_mod_op(game, &sp, "999_My Set", cfg, None);
+    disable_mod_op(game, &sp, "999_My Set", cfg, None).unwrap();
     assert!(
         !active.exists() && disabled.exists(),
         "disable moves the set out of the host"
     );
     assert!(
         !read_state(&sp)
+            .unwrap()
             .mods
             .iter()
             .find(|m| m.name == "BG Mod")
@@ -2095,13 +2110,14 @@ fn disable_then_enable_host_pack_moves_files() {
             .enabled
     );
 
-    enable_mod_op(game, &sp, "999_My Set", cfg, None);
+    enable_mod_op(game, &sp, "999_My Set", cfg, None).unwrap();
     assert!(
         active.exists() && !disabled.exists(),
         "enable moves the set back into the host"
     );
     assert!(
         read_state(&sp)
+            .unwrap()
             .mods
             .iter()
             .find(|m| m.name == "BG Mod")
@@ -2116,9 +2132,9 @@ fn reconcile_keeps_disabled_host_pack() {
     let game = tmp.path().to_str().unwrap();
     let cfg = engine_for_game("pd2").unwrap();
     install_host_pack_op(game, &sp, zip.path(), "My Set", bg_mod_data(), cfg).unwrap();
-    disable_mod_op(game, &sp, "999_My Set", cfg, None);
+    disable_mod_op(game, &sp, "999_My Set", cfg, None).unwrap();
 
-    let state = reconcile_state(game, &sp, cfg);
+    let state = reconcile_state(game, &sp, cfg).unwrap();
     let rec = state.mods.iter().find(|m| m.name == "BG Mod").unwrap();
     assert_eq!(
         rec.missing, None,
@@ -2132,12 +2148,12 @@ fn uninstall_removes_disabled_host_pack() {
     let game = tmp.path().to_str().unwrap();
     let cfg = engine_for_game("pd2").unwrap();
     install_host_pack_op(game, &sp, zip.path(), "My Set", bg_mod_data(), cfg).unwrap();
-    disable_mod_op(game, &sp, "999_My Set", cfg, None);
+    disable_mod_op(game, &sp, "999_My Set", cfg, None).unwrap();
 
-    uninstall_mod_op(game, &sp, "999_My Set", cfg);
+    uninstall_mod_op(game, &sp, "999_My Set", cfg).unwrap();
 
     assert!(!tmp.path().join("mods/disabled/host-17160/My Set").exists());
-    assert!(read_state(&sp).mods.iter().all(|m| m.id != 57135));
+    assert!(read_state(&sp).unwrap().mods.iter().all(|m| m.id != 57135));
 }
 
 #[test]
@@ -2942,8 +2958,9 @@ async fn unidentified_entry_self_heals_when_a_later_snapshot_gains_the_mod() {
             folders: state.folders.clone(),
             mods: mods.clone(),
         },
-    );
-    let mut stored = read_state(&state_path);
+    )
+    .unwrap();
+    let mut stored = read_state(&state_path).unwrap();
     let uid_before = stored.mods[0].uid.clone();
     let filename_before = stored.mods[0].filename.clone();
 
@@ -3015,7 +3032,7 @@ fn install_carries_iostore_sidecars_alongside_pak() {
     )
     .unwrap();
 
-    let filename = read_state(&sp).mods[0].filename.clone();
+    let filename = read_state(&sp).unwrap().mods[0].filename.clone();
     let stem = std::path::Path::new(&filename)
         .file_stem()
         .unwrap()
@@ -3051,7 +3068,7 @@ fn disable_then_enable_carries_iostore_sidecars() {
     )
     .unwrap();
 
-    let filename = read_state(&sp).mods[0].filename.clone();
+    let filename = read_state(&sp).unwrap().mods[0].filename.clone();
     let stem = std::path::Path::new(&filename)
         .file_stem()
         .unwrap()
@@ -3061,7 +3078,7 @@ fn disable_then_enable_carries_iostore_sidecars() {
     let active_dir = tmp.path().join("CrimeBoss/Content/Paks/~mods");
     let disabled_dir = active_dir.join("disabled");
 
-    disable_mod_op(game, &sp, "1", cfg, None);
+    disable_mod_op(game, &sp, "1", cfg, None).unwrap();
     assert!(!active_dir.join(format!("{stem}.ucas")).exists());
     assert!(!active_dir.join(format!("{stem}.utoc")).exists());
     // Disabled File-unit mods get both a different directory and a .disabled-suffixed
@@ -3069,7 +3086,7 @@ fn disable_then_enable_carries_iostore_sidecars() {
     assert!(disabled_dir.join(format!("{stem}.ucas.disabled")).exists());
     assert!(disabled_dir.join(format!("{stem}.utoc.disabled")).exists());
 
-    enable_mod_op(game, &sp, "1", cfg, None);
+    enable_mod_op(game, &sp, "1", cfg, None).unwrap();
     assert!(active_dir.join(format!("{stem}.ucas")).exists());
     assert!(active_dir.join(format!("{stem}.utoc")).exists());
     assert!(!disabled_dir.join(format!("{stem}.ucas")).exists());
@@ -3094,7 +3111,7 @@ fn uninstall_removes_iostore_sidecars() {
     )
     .unwrap();
 
-    let filename = read_state(&sp).mods[0].filename.clone();
+    let filename = read_state(&sp).unwrap().mods[0].filename.clone();
     let stem = std::path::Path::new(&filename)
         .file_stem()
         .unwrap()
@@ -3103,7 +3120,7 @@ fn uninstall_removes_iostore_sidecars() {
         .to_string();
     let active_dir = tmp.path().join("CrimeBoss/Content/Paks/~mods");
 
-    uninstall_mod_op(game, &sp, "1", cfg);
+    uninstall_mod_op(game, &sp, "1", cfg).unwrap();
 
     assert!(!active_dir.join(&filename).exists());
     assert!(!active_dir.join(format!("{stem}.ucas")).exists());
@@ -3219,17 +3236,17 @@ fn a_declared_extension_governs_install_disable_enable_and_uninstall() {
         "an unrelated stem-sharing file was taken"
     );
 
-    disable_mod_op(game, &sp, "1", cfg, None);
+    disable_mod_op(game, &sp, "1", cfg, None).unwrap();
     let disabled = active.join("disabled");
     assert!(disabled.join("TestMod.vpk.off").is_file());
     assert!(disabled.join("TestMod.vsig.off").is_file());
     assert!(!active.join("TestMod.vpk").exists());
 
-    enable_mod_op(game, &sp, "1", cfg, None);
+    enable_mod_op(game, &sp, "1", cfg, None).unwrap();
     assert!(active.join("TestMod.vpk").is_file());
     assert!(active.join("TestMod.vsig").is_file());
 
-    uninstall_mod_op(game, &sp, "1", cfg);
+    uninstall_mod_op(game, &sp, "1", cfg).unwrap();
     assert!(!active.join("TestMod.vpk").exists());
     assert!(!active.join("TestMod.vsig").exists());
 }
@@ -3327,7 +3344,7 @@ fn a_package_declaring_no_companions_installs_the_file_alone() {
     assert!(!active_dir.join("TestMod.ucas").exists());
     assert!(!active_dir.join("TestMod.sig").exists());
 
-    disable_mod_op(game, &sp, "1", cfg, None);
+    disable_mod_op(game, &sp, "1", cfg, None).unwrap();
     let disabled_dir = active_dir.join("disabled");
     assert!(disabled_dir.join("TestMod.pak.disabled").is_file());
     assert!(!disabled_dir.join("TestMod.ucas.disabled").exists());
@@ -3359,15 +3376,15 @@ fn a_package_declaring_its_own_companion_carries_that_one_and_no_other() {
     );
     assert!(!active_dir.join("TestMod.ucas").exists());
 
-    disable_mod_op(game, &sp, "1", cfg, None);
+    disable_mod_op(game, &sp, "1", cfg, None).unwrap();
     let disabled_dir = active_dir.join("disabled");
     assert!(disabled_dir.join("TestMod.sig.disabled").is_file());
     assert!(!active_dir.join("TestMod.sig").exists());
 
-    enable_mod_op(game, &sp, "1", cfg, None);
+    enable_mod_op(game, &sp, "1", cfg, None).unwrap();
     assert!(active_dir.join("TestMod.sig").is_file());
 
-    uninstall_mod_op(game, &sp, "1", cfg);
+    uninstall_mod_op(game, &sp, "1", cfg).unwrap();
     assert!(!active_dir.join("TestMod.pak").exists());
     assert!(!active_dir.join("TestMod.sig").exists());
 }
@@ -3682,7 +3699,7 @@ fn enable_mod_op_syncs_settings_when_files_are_at_active_path_but_state_says_dis
     .unwrap();
 
     // State as left by resync_crimeboss_enabled_flags: enabled=false but files at active path.
-    let mut s = read_state(&sp);
+    let mut s = read_state(&sp).unwrap();
     s.mods.push(InstalledMod {
         uid: "1".into(),
         id: 1,
@@ -3691,7 +3708,7 @@ fn enable_mod_op_syncs_settings_when_files_are_at_active_path_but_state_says_dis
         enabled: false,
         ..InstalledMod::default()
     });
-    save_state(&sp, &s);
+    save_state(&sp, &s).unwrap();
 
     // ModSettings file exists (game created it on first launch) with "false".
     let profile_tmp = TempDir::new().unwrap();
@@ -3704,7 +3721,7 @@ fn enable_mod_op_syncs_settings_when_files_are_at_active_path_but_state_says_dis
 
     std::env::set_var("USERPROFILE", profile_tmp.path());
 
-    enable_mod_op(game, &sp, "1", cfg, Some("steam"));
+    enable_mod_op(game, &sp, "1", cfg, Some("steam")).unwrap();
 
     std::env::remove_var("USERPROFILE");
 
@@ -3720,7 +3737,7 @@ fn enable_mod_op_syncs_settings_when_files_are_at_active_path_but_state_says_dis
         "settings file must be synced to true so the next resync doesn't immediately re-disable"
     );
     assert!(
-        read_state(&sp).mods[0].enabled,
+        read_state(&sp).unwrap().mods[0].enabled,
         "state must reflect enabled"
     );
 }
@@ -3831,19 +3848,19 @@ fn disable_then_enable_ue4ss_submod_edits_mods_txt_not_files() {
         .join("main.lua");
     assert!(main_lua.exists());
 
-    disable_mod_op(game, &sp, "1", cfg, None);
+    disable_mod_op(game, &sp, "1", cfg, None).unwrap();
     // The files never move. Only the mods.txt line and the tracked flag change.
     assert!(main_lua.exists());
     assert_eq!(
         read_enabled_from_mods_txt(&mods_txt, "CoolMod"),
         Some(false)
     );
-    assert!(!read_state(&sp).mods[0].enabled);
+    assert!(!read_state(&sp).unwrap().mods[0].enabled);
 
-    enable_mod_op(game, &sp, "1", cfg, None);
+    enable_mod_op(game, &sp, "1", cfg, None).unwrap();
     assert!(main_lua.exists());
     assert_eq!(read_enabled_from_mods_txt(&mods_txt, "CoolMod"), Some(true));
-    assert!(read_state(&sp).mods[0].enabled);
+    assert!(read_state(&sp).unwrap().mods[0].enabled);
 }
 
 #[test]
@@ -4036,7 +4053,7 @@ fn stage_crossed_submod(game: &TempDir, cfg: &ModEngineConfig) -> (PathBuf, Path
     fs::write(&mods_txt, "CoolMod : 1\r\n").unwrap();
 
     let sp = get_state_path(root, cfg);
-    let mut state = read_state(&sp);
+    let mut state = read_state(&sp).unwrap();
     state.mods.push(InstalledMod {
         uid: "1".into(),
         id: 1,
@@ -4045,7 +4062,7 @@ fn stage_crossed_submod(game: &TempDir, cfg: &ModEngineConfig) -> (PathBuf, Path
         enabled: true,
         ..InstalledMod::default()
     });
-    save_state(&sp, &state);
+    save_state(&sp, &state).unwrap();
     (sp, mods_txt, main_lua)
 }
 
@@ -4057,18 +4074,18 @@ fn the_mods_txt_mechanism_applies_under_a_tag_other_than_ue4ss_mods() {
     assert_eq!(cfg.primary().tag, "scripts");
     let (sp, mods_txt, main_lua) = stage_crossed_submod(&game, cfg);
 
-    disable_mod_op(root, &sp, "1", cfg, None);
+    disable_mod_op(root, &sp, "1", cfg, None).unwrap();
     assert!(main_lua.exists(), "the files must not move");
     assert_eq!(
         read_enabled_from_mods_txt(&mods_txt, "CoolMod"),
         Some(false)
     );
-    assert!(!read_state(&sp).mods[0].enabled);
+    assert!(!read_state(&sp).unwrap().mods[0].enabled);
 
-    enable_mod_op(root, &sp, "1", cfg, None);
+    enable_mod_op(root, &sp, "1", cfg, None).unwrap();
     assert!(main_lua.exists(), "the files must not move");
     assert_eq!(read_enabled_from_mods_txt(&mods_txt, "CoolMod"), Some(true));
-    assert!(read_state(&sp).mods[0].enabled);
+    assert!(read_state(&sp).unwrap().mods[0].enabled);
 }
 
 #[test]
@@ -4082,7 +4099,7 @@ fn the_ue4ss_mods_tag_alone_does_not_select_the_mods_txt_mechanism() {
         .join("Scripts")
         .join("main.lua");
 
-    disable_mod_op(root, &sp, "1", cfg, None);
+    disable_mod_op(root, &sp, "1", cfg, None).unwrap();
     assert!(!main_lua.exists());
     assert!(
         disabled_lua.exists(),
@@ -4093,13 +4110,13 @@ fn the_ue4ss_mods_tag_alone_does_not_select_the_mods_txt_mechanism() {
         Some(true),
         "mods.txt must be untouched"
     );
-    assert!(!read_state(&sp).mods[0].enabled);
+    assert!(!read_state(&sp).unwrap().mods[0].enabled);
 
-    enable_mod_op(root, &sp, "1", cfg, None);
+    enable_mod_op(root, &sp, "1", cfg, None).unwrap();
     assert!(main_lua.exists());
     assert!(!disabled_lua.exists());
     assert_eq!(read_enabled_from_mods_txt(&mods_txt, "CoolMod"), Some(true));
-    assert!(read_state(&sp).mods[0].enabled);
+    assert!(read_state(&sp).unwrap().mods[0].enabled);
 }
 
 // ── Crime Boss multi-pak bundle archives (ZIP_MULTI_PAK) ──────────────────────
@@ -4266,11 +4283,12 @@ fn reorder_skips_priority_prefix_for_targets_that_dont_use_it() {
                 },
             ],
         },
-    );
+    )
+    .unwrap();
 
-    reorder_mods_in_folder_op(game, &sp, None, &["b".to_string(), "a".to_string()], cfg);
+    reorder_mods_in_folder_op(game, &sp, None, &["b".to_string(), "a".to_string()], cfg).unwrap();
 
-    let state = read_state(&sp);
+    let state = read_state(&sp).unwrap();
     let filenames: Vec<&str> = state.mods.iter().map(|m| m.filename.as_str()).collect();
     assert_eq!(filenames, vec!["Foo", "Bar"]);
 }
@@ -4301,11 +4319,12 @@ fn reorder_applies_priority_prefix_for_targets_that_use_it() {
                 },
             ],
         },
-    );
+    )
+    .unwrap();
 
-    reorder_mods_in_folder_op(game, &sp, None, &["b".to_string(), "a".to_string()], cfg);
+    reorder_mods_in_folder_op(game, &sp, None, &["b".to_string(), "a".to_string()], cfg).unwrap();
 
-    let state = read_state(&sp);
+    let state = read_state(&sp).unwrap();
     let filenames: Vec<&str> = state.mods.iter().map(|m| m.filename.as_str()).collect();
     assert_eq!(filenames, vec!["001_Foo.pak", "002_Bar.pak"]);
 }
@@ -4350,7 +4369,7 @@ fn move_crimeboss_mod_unwraps_skeleton_into_legacy_paks() {
 
     move_crimeboss_mod_target_op(game, &sp, "a", cfg, None).unwrap();
 
-    let state = read_state(&sp);
+    let state = read_state(&sp).unwrap();
     let m = state.mods.iter().find(|m| m.uid == "a").unwrap();
     assert_eq!(m.location.as_deref(), Some("paks"));
     assert_eq!(m.filename, "001_FooCrimeBoss-WindowsNoEditor.pak");
@@ -4394,7 +4413,7 @@ fn move_crimeboss_mod_wraps_legacy_pak_into_skeleton() {
     )
     .unwrap();
     // priority_prefix is enabled for the legacy target, confirming the fixture is realistic.
-    let state = read_state(&sp);
+    let state = read_state(&sp).unwrap();
     assert_eq!(
         state.mods[0].filename,
         "001_FooCrimeBoss-WindowsNoEditor.pak"
@@ -4402,7 +4421,7 @@ fn move_crimeboss_mod_wraps_legacy_pak_into_skeleton() {
 
     move_crimeboss_mod_target_op(game, &sp, "a", cfg, None).unwrap();
 
-    let state = read_state(&sp);
+    let state = read_state(&sp).unwrap();
     let m = state.mods.iter().find(|m| m.uid == "a").unwrap();
     assert_eq!(m.location, None);
     assert_eq!(m.filename, mod_folder_name("Foo"));
@@ -4444,12 +4463,12 @@ fn move_crimeboss_mod_preserves_disabled_state() {
         cfg.primary(),
     )
     .unwrap();
-    disable_mod_op(game, &sp, "a", cfg, None);
-    assert!(!read_state(&sp).mods[0].enabled);
+    disable_mod_op(game, &sp, "a", cfg, None).unwrap();
+    assert!(!read_state(&sp).unwrap().mods[0].enabled);
 
     move_crimeboss_mod_target_op(game, &sp, "a", cfg, None).unwrap();
 
-    let state = read_state(&sp);
+    let state = read_state(&sp).unwrap();
     let m = state.mods.iter().find(|m| m.uid == "a").unwrap();
     assert!(!m.enabled);
     assert_eq!(m.location.as_deref(), Some("paks"));
@@ -4549,7 +4568,7 @@ fn read_state_migrates_legacy_version_sentinels() {
     )
     .unwrap();
 
-    let state = read_state(&path);
+    let state = read_state(&path).unwrap();
     assert_eq!(state.mods[0].update_status, UpdateStatus::Outdated);
     assert_eq!(
         state.mods[0].version, "",

--- a/apps/desktop/src-tauri/src/commands/mods/tests.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/tests.rs
@@ -3742,6 +3742,70 @@ fn enable_mod_op_syncs_settings_when_files_are_at_active_path_but_state_says_dis
     );
 }
 
+// Crime Boss activation is the settings file, not the folder, so writing it before the copies
+// on disk are understood meant a refused operation had already switched the mod on in-game.
+#[test]
+fn a_duplicated_crimeboss_mod_is_refused_before_the_game_is_switched() {
+    let game_tmp = TempDir::new().unwrap();
+    let game = game_tmp.path().to_str().unwrap();
+    let cfg = engine_for_game("cb").unwrap();
+    let sp = get_state_path(game, cfg);
+
+    for base in [
+        "CrimeBoss/Mods/M40_Dallas_Payday",
+        "CrimeBoss/Mods/disabled/M40_Dallas_Payday",
+    ] {
+        let pak_dir = game_tmp
+            .path()
+            .join(base)
+            .join("Content/Paks/WindowsNoEditor");
+        fs::create_dir_all(&pak_dir).unwrap();
+        fs::write(
+            pak_dir.join("M40DallasPDCrimeBoss-WindowsNoEditor.pak"),
+            b"pak",
+        )
+        .unwrap();
+    }
+
+    let mut state = read_state(&sp).unwrap();
+    state.mods.push(InstalledMod {
+        uid: "1".into(),
+        id: 1,
+        name: "M40 Dallas Payday".into(),
+        filename: "M40_Dallas_Payday".into(),
+        enabled: true,
+        ..InstalledMod::default()
+    });
+    save_state(&sp, &state).unwrap();
+
+    let profile_tmp = TempDir::new().unwrap();
+    let settings_dir = profile_tmp
+        .path()
+        .join("Saved Games/CrimeBoss/Steam/Saved/ModSettings");
+    fs::create_dir_all(&settings_dir).unwrap();
+    let settings_file = settings_dir.join("m40dallaspd.json");
+    let before = r#"[{"name":"enabled","value":"true"},{"name":"volume","value":"0.8"}]"#;
+    fs::write(&settings_file, before).unwrap();
+
+    std::env::set_var("USERPROFILE", profile_tmp.path());
+    let err = disable_mod_op(game, &sp, "1", cfg, Some("steam")).unwrap_err();
+    std::env::remove_var("USERPROFILE");
+
+    assert!(
+        err.contains("both the active and disabled folders"),
+        "unexpected error: {err}"
+    );
+    assert_eq!(
+        fs::read_to_string(&settings_file).unwrap(),
+        before,
+        "a refused disable must leave the game's own activation switch alone"
+    );
+    assert!(
+        read_state(&sp).unwrap().mods[0].enabled,
+        "the record must still say enabled"
+    );
+}
+
 // ── ue4ss_modstxt: UE4SS mods.txt sync ────────────────────────────────────────
 // Fixture matches the real UE4SS-CB mods.txt byte-for-byte (BOM, CRLF, blank lines, comment,
 // trailing "do not move up" warning), verified against the actual downloaded release.

--- a/apps/desktop/src-tauri/src/commands/mods/tests.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/tests.rs
@@ -5152,6 +5152,38 @@ fn installed_dir_fixture() -> (
     (tmp, game, sp, cfg)
 }
 
+/// Nothing moved here, so there is nothing to put back. Reversing anyway would carry the mod
+/// out of the location it was already sitting in before the toggle was asked for.
+#[test]
+fn a_failed_save_moves_nothing_back_when_nothing_moved() {
+    let (tmp, sp, cfg) = installed_pak_fixture();
+    let game = tmp.path().to_str().unwrap().to_string();
+    disable_mod_op(&game, &sp, "1", cfg, None).unwrap();
+    let filename = read_state(&sp).unwrap().mods[0].filename.clone();
+    // The record disagrees with the disk, which is the state an interrupted toggle leaves.
+    let mut state = read_state(&sp).unwrap();
+    state.mods[0].enabled = true;
+    save_state(&sp, &state).unwrap();
+    let mut tmp_name = sp.file_name().unwrap().to_os_string();
+    tmp_name.push(".tmp");
+    fs::create_dir_all(sp.with_file_name(tmp_name)).unwrap();
+
+    let err = disable_mod_op(&game, &sp, "1", cfg, None).unwrap_err();
+
+    assert!(
+        err.contains("could not be saved"),
+        "unexpected message: {err}"
+    );
+    assert!(
+        paks_dir(&tmp)
+            .join("disabled")
+            .join(format!("{filename}.disabled"))
+            .is_file(),
+        "the pak must stay where it already was"
+    );
+    assert!(!paks_dir(&tmp).join(&filename).exists());
+}
+
 // ── Sidecar copy and remove ───────────────────────────────────────────────
 
 #[test]

--- a/apps/desktop/src-tauri/src/commands/mods/tests.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/tests.rs
@@ -1342,7 +1342,7 @@ fn reconcile_state_purges_already_tracked_bundled_ue4ss_submods() {
     )
     .unwrap();
 
-    let state = reconcile_state(game, &sp, cfg).unwrap();
+    let state = super::state::reconcile_state(game, &sp, cfg).unwrap();
     let names: Vec<&str> = state.mods.iter().map(|m| m.filename.as_str()).collect();
     assert_eq!(names, vec!["CoolMod"]);
 }
@@ -1384,7 +1384,7 @@ fn reconcile_state_recovers_source_identity_from_uid() {
     )
     .unwrap();
 
-    let state = reconcile_state(game, &sp, cfg).unwrap();
+    let state = super::state::reconcile_state(game, &sp, cfg).unwrap();
     let nexus = state.mods.iter().find(|m| m.source == "nexus").unwrap();
     assert_eq!(nexus.remote_id.as_deref(), Some("123"));
     assert_eq!(nexus.file_remote_id.as_deref(), Some("456"));
@@ -1429,7 +1429,7 @@ fn reconcile_state_leaves_unparsable_source_uid_alone() {
     )
     .unwrap();
 
-    let state = reconcile_state(game, &sp, cfg).unwrap();
+    let state = super::state::reconcile_state(game, &sp, cfg).unwrap();
     assert_eq!(state.mods[0].remote_id, None);
     assert_eq!(state.mods[0].file_remote_id, None);
 }
@@ -1467,7 +1467,7 @@ fn reconcile_state_backfills_remote_id_for_a_legacy_modworkshop_entry_without_to
     )
     .unwrap();
 
-    let mut state = reconcile_state(game, &sp, cfg).unwrap();
+    let mut state = super::state::reconcile_state(game, &sp, cfg).unwrap();
     let expected_id = crate::commands::sources::source_native_local_id("modworkshop", "58065");
     assert_eq!(state.mods[0].remote_id.as_deref(), Some("58065"));
     assert_eq!(state.mods[0].id, expected_id);
@@ -1526,7 +1526,7 @@ fn reconcile_state_repairs_a_source_native_id_wrongly_promoted_to_modworkshop() 
     )
     .unwrap();
 
-    let state = reconcile_state(game, &sp, cfg).unwrap();
+    let state = super::state::reconcile_state(game, &sp, cfg).unwrap();
     assert_eq!(state.mods[0].id, expected_id);
     assert_eq!(state.mods[0].name, "RinoHud", "only id is repaired");
 
@@ -1563,7 +1563,7 @@ fn reconcile_state_leaves_a_correct_source_native_id_alone() {
     )
     .unwrap();
 
-    let state = reconcile_state(game, &sp, cfg).unwrap();
+    let state = super::state::reconcile_state(game, &sp, cfg).unwrap();
     assert_eq!(state.mods[0].id, expected_id);
 }
 
@@ -1977,7 +1977,7 @@ fn reconcile_keeps_installed_host_pack() {
     let cfg = engine_for_game("pd2").unwrap();
     install_host_pack_op(game, &sp, zip.path(), "My Set", bg_mod_data(), cfg).unwrap();
 
-    let state = reconcile_state(game, &sp, cfg).unwrap();
+    let state = super::state::reconcile_state(game, &sp, cfg).unwrap();
     let rec = state.mods.iter().find(|m| m.name == "BG Mod").unwrap();
     assert_eq!(
         rec.missing, None,
@@ -2134,7 +2134,7 @@ fn reconcile_keeps_disabled_host_pack() {
     install_host_pack_op(game, &sp, zip.path(), "My Set", bg_mod_data(), cfg).unwrap();
     disable_mod_op(game, &sp, "999_My Set", cfg, None).unwrap();
 
-    let state = reconcile_state(game, &sp, cfg).unwrap();
+    let state = super::state::reconcile_state(game, &sp, cfg).unwrap();
     let rec = state.mods.iter().find(|m| m.name == "BG Mod").unwrap();
     assert_eq!(
         rec.missing, None,
@@ -4843,6 +4843,100 @@ fn a_locked_state_file_is_left_alone_and_reads_again_once_released() {
 
     assert_untouched(&path, &before);
     assert_eq!(read_state(&path).unwrap().mods.len(), 2);
+}
+
+/// A game folder whose state file holds the given bytes, ready for a scan.
+fn scan_fixture(body: &[u8]) -> (TempDir, std::path::PathBuf, &'static ModEngineConfig) {
+    let tmp = TempDir::new().unwrap();
+    let cfg = engine_for_game("pd3").unwrap();
+    let sp = get_state_path(tmp.path().to_str().unwrap(), cfg);
+    fs::create_dir_all(sp.parent().unwrap()).unwrap();
+    fs::write(&sp, body).unwrap();
+    (tmp, sp, cfg)
+}
+
+/// The state a scan would have rebuilt, which is exactly what must not be written back.
+fn rebuilt_state() -> ModsState {
+    ModsState {
+        folders: vec![],
+        mods: vec![InstalledMod {
+            uid: "scanned".into(),
+            name: "Scanned".into(),
+            filename: "scanned.pak".into(),
+            ..Default::default()
+        }],
+    }
+}
+
+// get_installed keeps working when the state file will not load: the scan still describes the
+// mods on disk. What it must never do is save that description, because the folders, ordering
+// and per-mod metadata exist only in the file it could not read.
+#[test]
+fn a_scan_over_an_unreadable_state_file_may_not_write_it_back() {
+    let (tmp, sp, cfg) = scan_fixture(b"{ not json");
+    let before = fs::read(&sp).unwrap();
+
+    let (state, writeback) = load_for_scan(tmp.path().to_str().unwrap(), &sp, cfg);
+
+    assert!(
+        writeback.blocked(),
+        "an unreadable state must block the save"
+    );
+    assert!(state.mods.is_empty(), "the scan starts from an empty state");
+    assert!(state.folders.is_empty());
+
+    writeback.save(&sp, &rebuilt_state(), "the scanned state");
+    assert_untouched(&sp, &before);
+}
+
+// A file that parses as JSON but not as a state is the more dangerous case: the old reader
+// accepted it and silently dropped whatever did not fit.
+#[test]
+fn a_scan_over_an_invalid_state_file_may_not_write_it_back() {
+    let body = TWO_MODS.replace(r#""name":"Beta","#, "");
+    let (tmp, sp, cfg) = scan_fixture(body.as_bytes());
+    let before = fs::read(&sp).unwrap();
+
+    let (_state, writeback) = load_for_scan(tmp.path().to_str().unwrap(), &sp, cfg);
+
+    assert!(writeback.blocked());
+    writeback.save(&sp, &rebuilt_state(), "refreshed identities");
+    assert_untouched(&sp, &before);
+}
+
+#[test]
+fn a_scan_over_a_readable_state_file_writes_back_normally() {
+    let (tmp, sp, cfg) = scan_fixture(TWO_MODS.as_bytes());
+
+    let (state, writeback) = load_for_scan(tmp.path().to_str().unwrap(), &sp, cfg);
+
+    assert!(!writeback.blocked());
+    assert_eq!(state.mods.len(), 2);
+
+    writeback.save(&sp, &rebuilt_state(), "the scanned state");
+    let saved = read_state(&sp).unwrap();
+    assert_eq!(saved.mods.len(), 1);
+    assert_eq!(saved.mods[0].uid, "scanned");
+}
+
+// Degraded mode is a state of the file, not of the session: repairing the file must restore
+// saving without a restart, or a user who fixes their mod list stays stuck read-only.
+#[test]
+fn persistence_resumes_once_the_state_file_reads_again() {
+    let (tmp, sp, cfg) = scan_fixture(b"{ not json");
+    let game = tmp.path().to_str().unwrap();
+    let before = fs::read(&sp).unwrap();
+
+    let (_state, blocked) = load_for_scan(game, &sp, cfg);
+    blocked.save(&sp, &rebuilt_state(), "the scanned state");
+    assert_untouched(&sp, &before);
+
+    fs::write(&sp, TWO_MODS.as_bytes()).unwrap();
+    let (_state, allowed) = load_for_scan(game, &sp, cfg);
+
+    assert!(!allowed.blocked());
+    allowed.save(&sp, &rebuilt_state(), "the scanned state");
+    assert_eq!(read_state(&sp).unwrap().mods[0].uid, "scanned");
 }
 
 // ── Activation transitions ────────────────────────────────────────────────

--- a/apps/desktop/src-tauri/src/commands/mods/types.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/types.rs
@@ -198,4 +198,9 @@ pub struct InstalledResponse {
     pub mods: Vec<InstalledMod>,
     pub folders: Vec<ModFolder>,
     pub mods_hidden: bool,
+    /// The mod list on disk could not be loaded, so this response was rebuilt from a scan and
+    /// nothing was written back. Everything shown is real, but Modrex's own record of folders,
+    /// order and per-mod metadata is not in it, and no operation may replace that record until
+    /// the file is readable again.
+    pub state_unreadable: bool,
 }

--- a/apps/desktop/src-tauri/src/commands/mods/ue4ss_modstxt.rs
+++ b/apps/desktop/src-tauri/src/commands/mods/ue4ss_modstxt.rs
@@ -78,13 +78,13 @@ pub(crate) fn read_enabled_from_mods_txt(path: &Path, mod_name: &str) -> Option<
     })
 }
 
-/// Syncs a UE4SS Lua sub-mod's enabled state into mods.txt to match a Modrex enable or
-/// disable action. UE4SS reads this file on launch to decide which Mods/ folders load,
-/// independent of where the folder physically sits, so this and not a file move is what
-/// takes effect in-game. Silently no-ops on any I/O failure, the same tolerance
-/// crimeboss_settings::sync_enabled has, since the Modrex-tracked flag is what the UI shows.
-pub fn sync_enabled(mods_txt_path: &Path, mod_name: &str, enabled: bool) {
-    let _ = set_enabled_in_mods_txt(mods_txt_path, mod_name, enabled);
+/// Sets a UE4SS Lua sub-mod's enabled state in mods.txt to match a Modrex enable or disable
+/// action. UE4SS reads this file on launch to decide which Mods/ folders load, independent of
+/// where the folder physically sits, so this write and not a file move is what takes effect
+/// in-game. A failure therefore means the mod did not change state, and the caller has to
+/// hear about it rather than record a change the loader will not honour.
+pub fn set_enabled(mods_txt_path: &Path, mod_name: &str, enabled: bool) -> Result<(), String> {
+    set_enabled_in_mods_txt(mods_txt_path, mod_name, enabled)
 }
 
 /// Reads the real enabled value back from mods.txt. The player, or UE4SS's own in-game UI,

--- a/apps/desktop/src-tauri/src/commands/pak_viewer.rs
+++ b/apps/desktop/src-tauri/src/commands/pak_viewer.rs
@@ -111,7 +111,7 @@ pub async fn list_pak_assets(
     else {
         return Err(format!("{game_id} has no configured game path"));
     };
-    let state = read_state(&get_state_path(&game_path, cfg));
+    let state = read_state(&get_state_path(&game_path, cfg)).map_err(|e| e.to_string())?;
     let Some(m) = state.mods.iter().find(|m| m.uid == uid) else {
         return Err("installed mod not found".to_string());
     };

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -112,6 +112,7 @@ export default function App() {
     const [readyGames, setReadyGames] = useState<ReadonlySet<GameId>>(new Set())
     const startupPending = useRef(true)
     const [modsHidden, setModsHidden] = useState(false)
+    const [stateUnreadable, setStateUnreadable] = useState(false)
     const [restoreError, setRestoreError] = useState<string | null>(null)
     const [update, setUpdate] = useState<{
         version: string
@@ -179,7 +180,17 @@ export default function App() {
 
     // undefined = not yet loaded.
     const installedCache = useRef<
-        Partial<Record<GameId, { mods: InstalledMod[]; folders: ModFolder[]; modsHidden: boolean }>>
+        Partial<
+            Record<
+                GameId,
+                {
+                    mods: InstalledMod[]
+                    folders: ModFolder[]
+                    modsHidden: boolean
+                    stateUnreadable: boolean
+                }
+            >
+        >
     >({})
 
     const refreshGamePath = useCallback(async () => {
@@ -239,10 +250,12 @@ export default function App() {
                 setInstalled(cachedInstalled.mods)
                 setFolders(cachedInstalled.folders)
                 setModsHidden(cachedInstalled.modsHidden)
+                setStateUnreadable(cachedInstalled.stateUnreadable)
             } else {
                 setInstalled([])
                 setFolders([])
                 setModsHidden(false)
+                setStateUnreadable(false)
             }
             setView(dest)
         })
@@ -265,6 +278,7 @@ export default function App() {
             setInstalled(result.mods)
             setFolders(result.folders)
             setModsHidden(result.modsHidden)
+            setStateUnreadable(result.stateUnreadable)
             setReadyGames((prev) => (prev.has(game) ? prev : new Set(prev).add(game)))
         } finally {
             isRefreshingInstalled.current = false
@@ -559,6 +573,11 @@ export default function App() {
                         onDismissUpdate={() => setUpdate(null)}
                         hideGameActions={!gameInScope}
                     />
+                    {gameInScope && stateUnreadable && (
+                        <div className="shrink-0 px-4 py-2 bg-warning/10 border-b border-warning/30 text-xs text-warning">
+                            {t('app.stateUnreadable')}
+                        </div>
+                    )}
                     {gameInScope && modsHidden && (
                         <div className="shrink-0 flex items-center justify-between gap-4 px-4 py-2 bg-warning/10 border-b border-warning/30 text-xs text-warning">
                             <span>{t('app.modsHidden')}</span>

--- a/apps/desktop/src/renderer/src/api.ts
+++ b/apps/desktop/src/renderer/src/api.ts
@@ -283,13 +283,17 @@ export const api = {
     },
 
     // ── Installed mods ─────────────────────────────────────────────────────────
-    getInstalled(
-        gameId: string
-    ): Promise<{ mods: InstalledMod[]; folders: ModFolder[]; modsHidden: boolean }> {
+    getInstalled(gameId: string): Promise<{
+        mods: InstalledMod[]
+        folders: ModFolder[]
+        modsHidden: boolean
+        stateUnreadable: boolean
+    }> {
         return commands.getInstalled(gameId) as unknown as Promise<{
             mods: InstalledMod[]
             folders: ModFolder[]
             modsHidden: boolean
+            stateUnreadable: boolean
         }>
     },
     async openModsFolder(gameId: string): Promise<void> {

--- a/apps/desktop/src/renderer/src/bulkAction.test.ts
+++ b/apps/desktop/src/renderer/src/bulkAction.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { attemptAll, describeFailures } from './bulkAction'
+
+describe('attemptAll', () => {
+    // Stopping at the first failure leaves the rest of a selection untouched with nothing
+    // said about which were reached, so every item is attempted.
+    it('attempts every item even after one fails', async () => {
+        const attempted: string[] = []
+        const failures = await attemptAll(
+            ['a', 'b', 'c'],
+            (name) => name,
+            async (name) => {
+                attempted.push(name)
+                if (name === 'b') throw new Error('locked')
+            }
+        )
+
+        expect(attempted).toEqual(['a', 'b', 'c'])
+        expect(failures).toHaveLength(1)
+        expect(failures[0].name).toBe('b')
+        expect(failures[0].error).toContain('locked')
+    })
+
+    it('reports nothing when every item succeeds', async () => {
+        const failures = await attemptAll(
+            ['a', 'b'],
+            (n) => n,
+            async () => {}
+        )
+        expect(failures).toEqual([])
+    })
+
+    it('collects every failure, in order', async () => {
+        const failures = await attemptAll(
+            ['a', 'b', 'c'],
+            (n) => n,
+            async (n) => {
+                if (n !== 'b') throw new Error(`no ${n}`)
+            }
+        )
+        expect(failures.map((f) => f.name)).toEqual(['a', 'c'])
+    })
+})
+
+describe('describeFailures', () => {
+    it('says nothing when there is nothing to say', () => {
+        expect(describeFailures([])).toBeNull()
+    })
+
+    it('names the mod when one failed', () => {
+        const message = describeFailures([{ name: 'Cool Mod', error: 'file is locked' }])
+        expect(message).toContain('Cool Mod')
+        expect(message).toContain('file is locked')
+    })
+
+    it('names every mod when several failed and carries one reason', () => {
+        const message = describeFailures([
+            { name: 'Alpha', error: 'file is locked' },
+            { name: 'Beta', error: 'file is locked' },
+        ])
+        expect(message).toContain('Alpha')
+        expect(message).toContain('Beta')
+        expect(message).toContain('file is locked')
+    })
+})

--- a/apps/desktop/src/renderer/src/bulkAction.test.ts
+++ b/apps/desktop/src/renderer/src/bulkAction.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { attemptAll, describeFailures } from './bulkAction'
+import { describe, it, expect, vi } from 'vitest'
+import { attemptAll, describeFailures, runBulkAction } from './bulkAction'
 
 describe('attemptAll', () => {
     // Stopping at the first failure leaves the rest of a selection untouched with nothing
@@ -61,5 +61,74 @@ describe('describeFailures', () => {
         expect(message).toContain('Alpha')
         expect(message).toContain('Beta')
         expect(message).toContain('file is locked')
+    })
+})
+
+describe('runBulkAction', () => {
+    const ok = async (): Promise<void> => {}
+
+    it('refreshes once after the action and reports nothing when both succeed', async () => {
+        const refresh = vi.fn().mockResolvedValue(undefined)
+        const message = await runBulkAction(['a', 'b'], (n) => n, ok, refresh)
+
+        expect(message).toBeNull()
+        expect(refresh).toHaveBeenCalledTimes(1)
+    })
+
+    it('refreshes once even when every item failed', async () => {
+        const refresh = vi.fn().mockResolvedValue(undefined)
+        const message = await runBulkAction(
+            ['a'],
+            (n) => n,
+            async () => {
+                throw new Error('locked')
+            },
+            refresh
+        )
+
+        expect(message).toContain('locked')
+        expect(refresh).toHaveBeenCalledTimes(1)
+    })
+
+    // The callers are click handlers nobody awaits, so a rejection escaping here would skip
+    // their loading-flag reset and land on the global unhandledrejection handler.
+    it('reports a failed refresh instead of throwing', async () => {
+        const refresh = vi.fn().mockRejectedValue(new Error('the list could not be read'))
+
+        const message = await runBulkAction(['a'], (n) => n, ok, refresh)
+
+        expect(message).toContain('the list could not be read')
+    })
+
+    // Two failures, one banner: which mod would not move is more actionable than the fact that
+    // the list behind it is also unreadable.
+    it('keeps the action failure when the refresh fails too', async () => {
+        const message = await runBulkAction(
+            ['a'],
+            (n) => n,
+            async () => {
+                throw new Error('locked')
+            },
+            vi.fn().mockRejectedValue(new Error('the list could not be read'))
+        )
+
+        expect(message).toContain('locked')
+        expect(message).not.toContain('the list could not be read')
+    })
+
+    it('attempts every item before refreshing', async () => {
+        const order: string[] = []
+        await runBulkAction(
+            ['a', 'b'],
+            (n) => n,
+            async (n) => {
+                order.push(n)
+            },
+            async () => {
+                order.push('refresh')
+            }
+        )
+
+        expect(order).toEqual(['a', 'b', 'refresh'])
     })
 })

--- a/apps/desktop/src/renderer/src/bulkAction.ts
+++ b/apps/desktop/src/renderer/src/bulkAction.ts
@@ -1,0 +1,48 @@
+import { t } from './i18n'
+
+export interface ActionFailure {
+    name: string
+    error: string
+}
+
+/**
+ * Runs one action per mod and attempts every one, collecting the failures.
+ *
+ * Stopping at the first failure leaves the rest untouched with nothing said about which were
+ * reached, and the ones that already succeeded have already been written to disk. A locked
+ * file in the middle of a folder toggle should not decide the fate of the mods after it.
+ */
+export async function attemptAll<T>(
+    items: T[],
+    nameOf: (item: T) => string,
+    run: (item: T) => Promise<void>
+): Promise<ActionFailure[]> {
+    const failures: ActionFailure[] = []
+    for (const item of items) {
+        try {
+            await run(item)
+        } catch (e) {
+            failures.push({ name: nameOf(item), error: String(e) })
+        }
+    }
+    return failures
+}
+
+/**
+ * One message for a batch. A single failure reads as itself; several name the mods and carry
+ * the first reason, which is almost always the reason for all of them.
+ */
+export function describeFailures(failures: ActionFailure[]): string | null {
+    if (failures.length === 0) return null
+    if (failures.length === 1) {
+        return t('installed.actionFailed', {
+            name: failures[0].name,
+            error: failures[0].error,
+        })
+    }
+    return t('installed.actionFailedSome', {
+        count: failures.length,
+        names: failures.map((f) => f.name).join(', '),
+        error: failures[0].error,
+    })
+}

--- a/apps/desktop/src/renderer/src/bulkAction.ts
+++ b/apps/desktop/src/renderer/src/bulkAction.ts
@@ -46,3 +46,27 @@ export function describeFailures(failures: ActionFailure[]): string | null {
         error: failures[0].error,
     })
 }
+
+/**
+ * Runs an action over every item and then refreshes once, returning the message to show.
+ *
+ * The refresh is what makes the list show what is on disk rather than what was asked for, so it
+ * runs whether or not the action failed. Its own failure is returned rather than thrown: the
+ * callers are click handlers that nobody awaits, so a rejection escaping here would leave their
+ * loading flag set and reach the global unhandledrejection handler instead of the banner.
+ */
+export async function runBulkAction<T>(
+    items: T[],
+    nameOf: (item: T) => string,
+    run: (item: T) => Promise<void>,
+    refresh: () => Promise<void>
+): Promise<string | null> {
+    const actionError = describeFailures(await attemptAll(items, nameOf, run))
+    try {
+        await refresh()
+    } catch (e) {
+        // The action's own failure is the more specific one, so it keeps the single banner.
+        return actionError ?? t('installed.refreshFailed', { error: String(e) })
+    }
+    return actionError
+}

--- a/apps/desktop/src/renderer/src/components/BrowsePage.tsx
+++ b/apps/desktop/src/renderer/src/components/BrowsePage.tsx
@@ -49,7 +49,7 @@ import { useLoaderState } from '../hooks/useLoaderState'
 import { resolveDepCheck } from '../installDepCheck'
 import { t } from '../i18n'
 import { api } from '../api'
-import { attemptAll, describeFailures } from '../bulkAction'
+import { runBulkAction } from '../bulkAction'
 import { trackSearch } from '../lib/analytics/events'
 import { markForegroundActivity, waitForForegroundClear } from '../requestPriority'
 
@@ -614,14 +614,15 @@ export function BrowsePage({
             if (uids.length === 0) return
             addInstalling(modId)
             try {
-                const failures = await attemptAll(
-                    uids,
-                    () => installed.find((m) => uids.includes(m.uid))?.name ?? '',
-                    (uid) => api.enableMod(uid, gamePath, activeGame)
+                setActionError(
+                    await runBulkAction(
+                        uids,
+                        (uid) => installed.find((m) => m.uid === uid)?.name ?? '',
+                        (uid) => api.enableMod(uid, gamePath, activeGame),
+                        onRefreshInstalled
+                    )
                 )
-                setActionError(describeFailures(failures))
             } finally {
-                await onRefreshInstalled()
                 removeInstalling(modId)
             }
         },
@@ -640,14 +641,15 @@ export function BrowsePage({
             if (uids.length === 0) return
             addInstalling(modId)
             try {
-                const failures = await attemptAll(
-                    uids,
-                    () => installed.find((m) => uids.includes(m.uid))?.name ?? '',
-                    (uid) => api.disableMod(uid, gamePath, activeGame)
+                setActionError(
+                    await runBulkAction(
+                        uids,
+                        (uid) => installed.find((m) => m.uid === uid)?.name ?? '',
+                        (uid) => api.disableMod(uid, gamePath, activeGame),
+                        onRefreshInstalled
+                    )
                 )
-                setActionError(describeFailures(failures))
             } finally {
-                await onRefreshInstalled()
                 removeInstalling(modId)
             }
         },

--- a/apps/desktop/src/renderer/src/components/BrowsePage.tsx
+++ b/apps/desktop/src/renderer/src/components/BrowsePage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef, useMemo, memo, startTransition } from 'react'
 import { TITLE_ROW_MIN_H } from './pageHeader'
-import { Search, LayoutGrid, ArrowDownUp } from 'lucide-react'
+import { Search, LayoutGrid, ArrowDownUp, X } from 'lucide-react'
 import type {
     Mod,
     ModFile,
@@ -49,6 +49,7 @@ import { useLoaderState } from '../hooks/useLoaderState'
 import { resolveDepCheck } from '../installDepCheck'
 import { t } from '../i18n'
 import { api } from '../api'
+import { attemptAll, describeFailures } from '../bulkAction'
 import { trackSearch } from '../lib/analytics/events'
 import { markForegroundActivity, waitForForegroundClear } from '../requestPriority'
 
@@ -238,6 +239,9 @@ export function BrowsePage({
         ReadonlyMap<string, { downloaded: number; total: number }>
     >(new Map())
     const [error, setError] = useState<string | null>(null)
+    // Enable, disable and uninstall report separately from a failed listing fetch: the grid
+    // stays usable, so hiding it behind the fetch error would be wrong.
+    const [actionError, setActionError] = useState<string | null>(null)
     const [depsWarning, setDepsWarning] = useState<{
         modId: number
         allDeps: ModDependency[]
@@ -610,9 +614,14 @@ export function BrowsePage({
             if (uids.length === 0) return
             addInstalling(modId)
             try {
-                for (const uid of uids) await api.enableMod(uid, gamePath, activeGame)
-                await onRefreshInstalled()
+                const failures = await attemptAll(
+                    uids,
+                    () => installed.find((m) => uids.includes(m.uid))?.name ?? '',
+                    (uid) => api.enableMod(uid, gamePath, activeGame)
+                )
+                setActionError(describeFailures(failures))
             } finally {
+                await onRefreshInstalled()
                 removeInstalling(modId)
             }
         },
@@ -631,9 +640,14 @@ export function BrowsePage({
             if (uids.length === 0) return
             addInstalling(modId)
             try {
-                for (const uid of uids) await api.disableMod(uid, gamePath, activeGame)
-                await onRefreshInstalled()
+                const failures = await attemptAll(
+                    uids,
+                    () => installed.find((m) => uids.includes(m.uid))?.name ?? '',
+                    (uid) => api.disableMod(uid, gamePath, activeGame)
+                )
+                setActionError(describeFailures(failures))
             } finally {
+                await onRefreshInstalled()
                 removeInstalling(modId)
             }
         },
@@ -839,6 +853,18 @@ export function BrowsePage({
                     />
                 </div>
             </div>
+
+            {actionError && (
+                <div className="mx-6 mt-4 px-4 py-3 bg-danger/30 border border-danger-hover rounded text-sm text-danger-text flex items-center justify-between gap-3">
+                    <span className="truncate">{actionError}</span>
+                    <button
+                        onClick={() => setActionError(null)}
+                        className="shrink-0 hover:opacity-70 transition-opacity"
+                    >
+                        <X className="w-4 h-4" />
+                    </button>
+                </div>
+            )}
 
             {error &&
                 (isRateLimitError(error) ? (

--- a/apps/desktop/src/renderer/src/components/InstalledPage.tsx
+++ b/apps/desktop/src/renderer/src/components/InstalledPage.tsx
@@ -150,6 +150,8 @@ export function InstalledPage({
         reinstallProgress,
         reinstallError,
         clearReinstallError,
+        modActionError,
+        clearModActionError,
         refreshing,
         zipPickerData,
         clearZipPickerData,
@@ -443,6 +445,28 @@ export function InstalledPage({
                     )}
                 </div>
 
+                {modActionError && (
+                    <div className="px-6 py-2 shrink-0 flex items-center justify-between gap-3 bg-danger/10 border-b border-danger/30 text-danger text-xs">
+                        <span className="truncate">{modActionError}</span>
+                        <button
+                            onClick={clearModActionError}
+                            className="shrink-0 hover:opacity-70 transition-opacity"
+                        >
+                            <X className="w-3.5 h-3.5" />
+                        </button>
+                    </div>
+                )}
+                {folderActions.folderActionError && (
+                    <div className="px-6 py-2 shrink-0 flex items-center justify-between gap-3 bg-danger/10 border-b border-danger/30 text-danger text-xs">
+                        <span className="truncate">{folderActions.folderActionError}</span>
+                        <button
+                            onClick={folderActions.clearFolderActionError}
+                            className="shrink-0 hover:opacity-70 transition-opacity"
+                        >
+                            <X className="w-3.5 h-3.5" />
+                        </button>
+                    </div>
+                )}
                 {reinstallError && (
                     <div className="px-6 py-2 shrink-0 flex items-center justify-between gap-3 bg-danger/10 border-b border-danger/30 text-danger text-xs">
                         <span className="truncate">

--- a/apps/desktop/src/renderer/src/components/ModDetailPage.tsx
+++ b/apps/desktop/src/renderer/src/components/ModDetailPage.tsx
@@ -69,7 +69,7 @@ import { useLoaderState } from '../hooks/useLoaderState'
 import { resolveDepCheck } from '../installDepCheck'
 import { useThumbnail } from '../hooks/useThumbnail'
 import { api } from '../api'
-import { attemptAll, describeFailures } from '../bulkAction'
+import { runBulkAction } from '../bulkAction'
 import { markForegroundActivity } from '../requestPriority'
 import { DescriptionTab, ChangelogTab, LicenseTab } from './modDetail/textTabs'
 import { LightboxImage, ImagesTab } from './modDetail/ImagesTab'
@@ -546,14 +546,15 @@ export function ModDetailPage({
         setActionLoading(true)
         setInstallError(null)
         try {
-            const failures = await attemptAll(
-                installedFiles,
-                (m) => m.name,
-                (m) => api.enableMod(m.uid, gamePath, activeGame)
+            setInstallError(
+                await runBulkAction(
+                    installedFiles,
+                    (m) => m.name,
+                    (m) => api.enableMod(m.uid, gamePath, activeGame),
+                    onRefreshInstalled
+                )
             )
-            setInstallError(describeFailures(failures))
         } finally {
-            await onRefreshInstalled()
             setActionLoading(false)
         }
     }
@@ -563,14 +564,15 @@ export function ModDetailPage({
         setActionLoading(true)
         setInstallError(null)
         try {
-            const failures = await attemptAll(
-                installedFiles,
-                (m) => m.name,
-                (m) => api.disableMod(m.uid, gamePath, activeGame)
+            setInstallError(
+                await runBulkAction(
+                    installedFiles,
+                    (m) => m.name,
+                    (m) => api.disableMod(m.uid, gamePath, activeGame),
+                    onRefreshInstalled
+                )
             )
-            setInstallError(describeFailures(failures))
         } finally {
-            await onRefreshInstalled()
             setActionLoading(false)
         }
     }

--- a/apps/desktop/src/renderer/src/components/ModDetailPage.tsx
+++ b/apps/desktop/src/renderer/src/components/ModDetailPage.tsx
@@ -69,6 +69,7 @@ import { useLoaderState } from '../hooks/useLoaderState'
 import { resolveDepCheck } from '../installDepCheck'
 import { useThumbnail } from '../hooks/useThumbnail'
 import { api } from '../api'
+import { attemptAll, describeFailures } from '../bulkAction'
 import { markForegroundActivity } from '../requestPriority'
 import { DescriptionTab, ChangelogTab, LicenseTab } from './modDetail/textTabs'
 import { LightboxImage, ImagesTab } from './modDetail/ImagesTab'
@@ -543,10 +544,16 @@ export function ModDetailPage({
     async function handleEnable() {
         if (!gamePath || installedFiles.length === 0) return
         setActionLoading(true)
+        setInstallError(null)
         try {
-            for (const m of installedFiles) await api.enableMod(m.uid, gamePath, activeGame)
-            await onRefreshInstalled()
+            const failures = await attemptAll(
+                installedFiles,
+                (m) => m.name,
+                (m) => api.enableMod(m.uid, gamePath, activeGame)
+            )
+            setInstallError(describeFailures(failures))
         } finally {
+            await onRefreshInstalled()
             setActionLoading(false)
         }
     }
@@ -554,10 +561,16 @@ export function ModDetailPage({
     async function handleDisable() {
         if (!gamePath || installedFiles.length === 0) return
         setActionLoading(true)
+        setInstallError(null)
         try {
-            for (const m of installedFiles) await api.disableMod(m.uid, gamePath, activeGame)
-            await onRefreshInstalled()
+            const failures = await attemptAll(
+                installedFiles,
+                (m) => m.name,
+                (m) => api.disableMod(m.uid, gamePath, activeGame)
+            )
+            setInstallError(describeFailures(failures))
         } finally {
+            await onRefreshInstalled()
             setActionLoading(false)
         }
     }

--- a/apps/desktop/src/renderer/src/hooks/useFolderActions.ts
+++ b/apps/desktop/src/renderer/src/hooks/useFolderActions.ts
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import type { GameId, InstalledMod, ModFolder } from '../../../shared/types'
 import { GAME_STORAGE_KEY } from '../../../shared/types'
 import { api } from '../api'
+import { attemptAll, describeFailures } from '../bulkAction'
 
 export interface FolderActions {
     collapsedFolders: Set<string>
@@ -11,6 +12,8 @@ export interface FolderActions {
     creatingFolderParentId: string | null | undefined
     newFolderName: string
     loadingFolderId: string | null
+    folderActionError: string | null
+    clearFolderActionError: () => void
     startRename: (folder: ModFolder) => void
     commitRename: (folderId: string) => Promise<void>
     cancelRename: () => void
@@ -47,6 +50,7 @@ export function useFolderActions(
     )
     const [newFolderName, setNewFolderName] = useState('')
     const [loadingFolderId, setLoadingFolderId] = useState<string | null>(null)
+    const [folderActionError, setFolderActionError] = useState<string | null>(null)
 
     function startRename(folder: ModFolder) {
         setRenamingFolderId(folder.id)
@@ -121,19 +125,24 @@ export function useFolderActions(
         })
     }
 
+    // A folder toggle is a batch: one mod that will not move must not decide the rest, and the
+    // refresh afterwards is what shows which ones actually changed.
     async function handleToggleFolder(folderId: string, mods: InstalledMod[], anyEnabled: boolean) {
         if (!gamePath) return
         setLoadingFolderId(folderId)
+        setFolderActionError(null)
         try {
-            for (const mod of mods) {
-                if (anyEnabled) {
-                    await api.disableMod(mod.uid, gamePath, activeGame)
-                } else {
-                    await api.enableMod(mod.uid, gamePath, activeGame)
-                }
-            }
-            await onRefreshInstalled()
+            const failures = await attemptAll(
+                mods,
+                (m) => m.name,
+                (m) =>
+                    anyEnabled
+                        ? api.disableMod(m.uid, gamePath, activeGame)
+                        : api.enableMod(m.uid, gamePath, activeGame)
+            )
+            setFolderActionError(describeFailures(failures))
         } finally {
+            await onRefreshInstalled()
             setLoadingFolderId(null)
         }
     }
@@ -146,6 +155,8 @@ export function useFolderActions(
         creatingFolderParentId,
         newFolderName,
         loadingFolderId,
+        folderActionError,
+        clearFolderActionError: () => setFolderActionError(null),
         startRename,
         commitRename,
         cancelRename,

--- a/apps/desktop/src/renderer/src/hooks/useFolderActions.ts
+++ b/apps/desktop/src/renderer/src/hooks/useFolderActions.ts
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import type { GameId, InstalledMod, ModFolder } from '../../../shared/types'
 import { GAME_STORAGE_KEY } from '../../../shared/types'
 import { api } from '../api'
-import { attemptAll, describeFailures } from '../bulkAction'
+import { runBulkAction } from '../bulkAction'
 
 export interface FolderActions {
     collapsedFolders: Set<string>
@@ -132,17 +132,18 @@ export function useFolderActions(
         setLoadingFolderId(folderId)
         setFolderActionError(null)
         try {
-            const failures = await attemptAll(
-                mods,
-                (m) => m.name,
-                (m) =>
-                    anyEnabled
-                        ? api.disableMod(m.uid, gamePath, activeGame)
-                        : api.enableMod(m.uid, gamePath, activeGame)
+            setFolderActionError(
+                await runBulkAction(
+                    mods,
+                    (m) => m.name,
+                    (m) =>
+                        anyEnabled
+                            ? api.disableMod(m.uid, gamePath, activeGame)
+                            : api.enableMod(m.uid, gamePath, activeGame),
+                    onRefreshInstalled
+                )
             )
-            setFolderActionError(describeFailures(failures))
         } finally {
-            await onRefreshInstalled()
             setLoadingFolderId(null)
         }
     }

--- a/apps/desktop/src/renderer/src/hooks/useModActions.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/useModActions.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, it, expect, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import type { InstalledMod } from '../../../shared/types'
+
+const disableMod = vi.fn<(uid: string, gamePath: string, gameId: string) => Promise<void>>()
+const enableMod = vi.fn<(uid: string, gamePath: string, gameId: string) => Promise<void>>()
+
+function mod(uid: string, name: string): InstalledMod {
+    return {
+        uid,
+        id: 1,
+        name,
+        version: '1.0',
+        filename: `${uid}.pak`,
+        enabled: true,
+        installedAt: '',
+    } as InstalledMod
+}
+
+async function loadHook() {
+    vi.resetModules()
+    vi.doMock('../api', () => ({
+        api: {
+            disableMod,
+            enableMod,
+            uninstallMod: vi.fn().mockResolvedValue(undefined),
+            onDownloadProgress: vi.fn(() => () => {}),
+            installMod: vi.fn(),
+        },
+    }))
+    return (await import('./useModActions')).useModActions
+}
+
+describe('useModActions bulk behaviour', () => {
+    beforeEach(() => {
+        disableMod.mockReset().mockResolvedValue(undefined)
+        enableMod.mockReset().mockResolvedValue(undefined)
+    })
+
+    // A locked file in the middle of a selection must not decide the fate of the mods after
+    // it, and the ones that already succeeded are on disk whatever happens next.
+    it('attempts every mod, refreshes once and reports the one that failed', async () => {
+        disableMod.mockImplementation(async (uid) => {
+            if (uid === 'b') throw new Error('the file is in use')
+        })
+        const onRefresh = vi.fn().mockResolvedValue(undefined)
+        const useModActions = await loadHook()
+        const { result } = renderHook(() => useModActions('C:/game', onRefresh, 'pd3'))
+
+        await result.current.handleDisable([mod('a', 'Alpha'), mod('b', 'Beta'), mod('c', 'Gamma')])
+
+        await waitFor(() => expect(result.current.modActionError).not.toBeNull())
+        expect(disableMod).toHaveBeenCalledTimes(3)
+        expect(onRefresh).toHaveBeenCalledTimes(1)
+        expect(result.current.modActionError).toContain('Beta')
+        expect(result.current.modActionError).not.toContain('Alpha')
+        expect(result.current.loadingMod).toBeNull()
+    })
+
+    // The list has to end up showing what is on disk, which is exactly what a caller cannot
+    // know after a failure.
+    it('refreshes even when every mod fails', async () => {
+        disableMod.mockRejectedValue(new Error('the file is in use'))
+        const onRefresh = vi.fn().mockResolvedValue(undefined)
+        const useModActions = await loadHook()
+        const { result } = renderHook(() => useModActions('C:/game', onRefresh, 'pd3'))
+
+        await result.current.handleDisable([mod('a', 'Alpha'), mod('b', 'Beta')])
+
+        await waitFor(() => expect(result.current.modActionError).not.toBeNull())
+        expect(onRefresh).toHaveBeenCalledTimes(1)
+        expect(result.current.loadingMod).toBeNull()
+    })
+
+    it('reports nothing and still refreshes when every mod succeeds', async () => {
+        const onRefresh = vi.fn().mockResolvedValue(undefined)
+        const useModActions = await loadHook()
+        const { result } = renderHook(() => useModActions('C:/game', onRefresh, 'pd3'))
+
+        await result.current.handleEnable([mod('a', 'Alpha'), mod('b', 'Beta')])
+
+        await waitFor(() => expect(result.current.loadingMod).toBeNull())
+        expect(enableMod).toHaveBeenCalledTimes(2)
+        expect(onRefresh).toHaveBeenCalledTimes(1)
+        expect(result.current.modActionError).toBeNull()
+    })
+
+    // A stale message from the previous attempt would read as a fresh failure.
+    it('clears a previous failure when the next attempt succeeds', async () => {
+        disableMod.mockRejectedValueOnce(new Error('the file is in use'))
+        const onRefresh = vi.fn().mockResolvedValue(undefined)
+        const useModActions = await loadHook()
+        const { result } = renderHook(() => useModActions('C:/game', onRefresh, 'pd3'))
+
+        await result.current.handleDisable([mod('a', 'Alpha')])
+        await waitFor(() => expect(result.current.modActionError).not.toBeNull())
+
+        await result.current.handleDisable([mod('a', 'Alpha')])
+        await waitFor(() => expect(result.current.modActionError).toBeNull())
+    })
+})

--- a/apps/desktop/src/renderer/src/hooks/useModActions.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/useModActions.test.tsx
@@ -86,6 +86,36 @@ describe('useModActions bulk behaviour', () => {
         expect(result.current.modActionError).toBeNull()
     })
 
+    // The refresh runs in the action's own cleanup, so a rejection there used to skip the
+    // loading reset and escape as an unhandled rejection, leaving the row spinning for good.
+    it('clears the loading state and reports when the refresh fails', async () => {
+        const onRefresh = vi.fn().mockRejectedValue(new Error('the list could not be read'))
+        const useModActions = await loadHook()
+        const { result } = renderHook(() => useModActions('C:/game', onRefresh, 'pd3'))
+
+        await result.current.handleDisable([mod('a', 'Alpha')])
+
+        await waitFor(() => expect(result.current.modActionError).not.toBeNull())
+        expect(result.current.loadingMod).toBeNull()
+        expect(result.current.modActionError).toContain('the list could not be read')
+        expect(onRefresh).toHaveBeenCalledTimes(1)
+        expect(disableMod).toHaveBeenCalledTimes(1)
+    })
+
+    it('keeps the mod failure when the refresh fails as well', async () => {
+        disableMod.mockRejectedValue(new Error('the file is in use'))
+        const onRefresh = vi.fn().mockRejectedValue(new Error('the list could not be read'))
+        const useModActions = await loadHook()
+        const { result } = renderHook(() => useModActions('C:/game', onRefresh, 'pd3'))
+
+        await result.current.handleDisable([mod('a', 'Alpha')])
+
+        await waitFor(() => expect(result.current.modActionError).not.toBeNull())
+        expect(result.current.loadingMod).toBeNull()
+        expect(result.current.modActionError).toContain('Alpha')
+        expect(result.current.modActionError).toContain('the file is in use')
+    })
+
     // A stale message from the previous attempt would read as a fresh failure.
     it('clears a previous failure when the next attempt succeeds', async () => {
         disableMod.mockRejectedValueOnce(new Error('the file is in use'))

--- a/apps/desktop/src/renderer/src/hooks/useModActions.ts
+++ b/apps/desktop/src/renderer/src/hooks/useModActions.ts
@@ -8,11 +8,14 @@ import { handleInstallOutcome } from '../installSentinels'
 import { entryFilename, stripPriorityPrefix } from './installedUtils'
 import { t } from '../i18n'
 import { api } from '../api'
+import { attemptAll, describeFailures } from '../bulkAction'
 
 export type IdentifyNexusResult = { kind: 'done' | 'error'; message: string }
 
 export interface ModActions {
     loadingMod: string | null
+    modActionError: string | null
+    clearModActionError: () => void
     reinstallProgress: { downloaded: number; total: number } | null
     reinstallError: string | null
     clearReinstallError: () => void
@@ -47,6 +50,7 @@ export function useModActions(
     activeGame: GameId
 ): ModActions {
     const [loadingMod, setLoadingMod] = useState<string | null>(null)
+    const [modActionError, setModActionError] = useState<string | null>(null)
     const [reinstallProgress, setReinstallProgress] = useState<{
         downloaded: number
         total: number
@@ -89,37 +93,31 @@ export function useModActions(
         }
     }
 
-    async function handleUninstall(mods: InstalledMod[]) {
+    // Every one of these attempts all of its mods, then refreshes once whether or not any
+    // failed, so the list shows what is actually on disk rather than what was asked for.
+    async function runOnEach(mods: InstalledMod[], run: (m: InstalledMod) => Promise<void>) {
         if (!gamePath) return
         setLoadingMod(mods[0].uid)
+        setModActionError(null)
         try {
-            for (const m of mods) await api.uninstallMod(m.uid, gamePath, activeGame)
-            await onRefreshInstalled()
+            const failures = await attemptAll(mods, (m) => m.name, run)
+            setModActionError(describeFailures(failures))
         } finally {
+            await onRefreshInstalled()
             setLoadingMod(null)
         }
+    }
+
+    async function handleUninstall(mods: InstalledMod[]) {
+        await runOnEach(mods, (m) => api.uninstallMod(m.uid, gamePath!, activeGame))
     }
 
     async function handleEnable(mods: InstalledMod[]) {
-        if (!gamePath) return
-        setLoadingMod(mods[0].uid)
-        try {
-            for (const m of mods) await api.enableMod(m.uid, gamePath, activeGame)
-            await onRefreshInstalled()
-        } finally {
-            setLoadingMod(null)
-        }
+        await runOnEach(mods, (m) => api.enableMod(m.uid, gamePath!, activeGame))
     }
 
     async function handleDisable(mods: InstalledMod[]) {
-        if (!gamePath) return
-        setLoadingMod(mods[0].uid)
-        try {
-            for (const m of mods) await api.disableMod(m.uid, gamePath, activeGame)
-            await onRefreshInstalled()
-        } finally {
-            setLoadingMod(null)
-        }
+        await runOnEach(mods, (m) => api.disableMod(m.uid, gamePath!, activeGame))
     }
 
     // Tier 3 identification (see nexus_content.rs): a miss or an ambiguous result is
@@ -277,6 +275,8 @@ export function useModActions(
 
     return {
         loadingMod,
+        modActionError,
+        clearModActionError: () => setModActionError(null),
         reinstallProgress,
         reinstallError,
         clearReinstallError: () => setReinstallError(null),

--- a/apps/desktop/src/renderer/src/hooks/useModActions.ts
+++ b/apps/desktop/src/renderer/src/hooks/useModActions.ts
@@ -8,7 +8,7 @@ import { handleInstallOutcome } from '../installSentinels'
 import { entryFilename, stripPriorityPrefix } from './installedUtils'
 import { t } from '../i18n'
 import { api } from '../api'
-import { attemptAll, describeFailures } from '../bulkAction'
+import { runBulkAction } from '../bulkAction'
 
 export type IdentifyNexusResult = { kind: 'done' | 'error'; message: string }
 
@@ -100,10 +100,8 @@ export function useModActions(
         setLoadingMod(mods[0].uid)
         setModActionError(null)
         try {
-            const failures = await attemptAll(mods, (m) => m.name, run)
-            setModActionError(describeFailures(failures))
+            setModActionError(await runBulkAction(mods, (m) => m.name, run, onRefreshInstalled))
         } finally {
-            await onRefreshInstalled()
             setLoadingMod(null)
         }
     }

--- a/apps/desktop/src/renderer/src/i18n/de.json
+++ b/apps/desktop/src/renderer/src/i18n/de.json
@@ -26,6 +26,7 @@
     },
     "app": {
         "modsHidden": "Mods sind versteckt — Das Spiel wurde unmodifiziert gestartet und läuft vielleicht noch.",
+        "stateUnreadable": "! Modrex could not read its own mod list for this game, so the mods below were found by scanning the folder and no changes are being saved. Details are in the log.",
         "restoreMods": "Mods wiederherstellen",
         "updateAction": "Aktualisieren",
         "updateInstall": "Neustart & Installation",
@@ -151,6 +152,8 @@
         "filterPlaceholder": "Mods durchsuchen…",
         "filterEmpty": "Keine Mods stimmen mit „{query}“ überein",
         "reinstallFailed": "Erneute Installation fehlgeschlagen: {error}",
+        "actionFailed": "! {name} could not be changed: {error}",
+        "actionFailedSome": "! {count} mods could not be changed ({names}): {error}",
         "updatesAvailable": "{count} Mods können aktualisiert werden",
         "updatesAvailableSingle": "{count} Mod kann aktualisiert werden",
         "reviewUpdates": "Updates überprüfen",

--- a/apps/desktop/src/renderer/src/i18n/de.json
+++ b/apps/desktop/src/renderer/src/i18n/de.json
@@ -154,6 +154,7 @@
         "reinstallFailed": "Erneute Installation fehlgeschlagen: {error}",
         "actionFailed": "! {name} could not be changed: {error}",
         "actionFailedSome": "! {count} mods could not be changed ({names}): {error}",
+        "refreshFailed": "! The installed mod list could not be refreshed: {error}",
         "updatesAvailable": "{count} Mods können aktualisiert werden",
         "updatesAvailableSingle": "{count} Mod kann aktualisiert werden",
         "reviewUpdates": "Updates überprüfen",

--- a/apps/desktop/src/renderer/src/i18n/en.json
+++ b/apps/desktop/src/renderer/src/i18n/en.json
@@ -154,6 +154,7 @@
         "reinstallFailed": "Reinstall failed: {error}",
         "actionFailed": "{name} could not be changed: {error}",
         "actionFailedSome": "{count} mods could not be changed ({names}): {error}",
+        "refreshFailed": "The installed mod list could not be refreshed: {error}",
         "updatesAvailable": "{count} mods can be updated",
         "updatesAvailableSingle": "{count} mod can be updated",
         "reviewUpdates": "Review updates",

--- a/apps/desktop/src/renderer/src/i18n/en.json
+++ b/apps/desktop/src/renderer/src/i18n/en.json
@@ -26,6 +26,7 @@
     },
     "app": {
         "modsHidden": "Mods are hidden; the game was launched in vanilla mode and may still be running.",
+        "stateUnreadable": "Modrex could not read its own mod list for this game, so the mods below were found by scanning the folder and no changes are being saved. Details are in the log.",
         "restoreMods": "Restore mods",
         "updateAction": "Update",
         "updateInstall": "Restart & Install",
@@ -151,6 +152,8 @@
         "filterPlaceholder": "Search mods...",
         "filterEmpty": "No mods match \"{query}\"",
         "reinstallFailed": "Reinstall failed: {error}",
+        "actionFailed": "{name} could not be changed: {error}",
+        "actionFailedSome": "{count} mods could not be changed ({names}): {error}",
         "updatesAvailable": "{count} mods can be updated",
         "updatesAvailableSingle": "{count} mod can be updated",
         "reviewUpdates": "Review updates",

--- a/apps/desktop/src/renderer/src/i18n/it.json
+++ b/apps/desktop/src/renderer/src/i18n/it.json
@@ -26,6 +26,7 @@
     },
     "app": {
         "modsHidden": "Le mod sono nascoste; il gioco è avviato in modalità vanilla e potrebbe essere ancora esecuzione.",
+        "stateUnreadable": "! Modrex could not read its own mod list for this game, so the mods below were found by scanning the folder and no changes are being saved. Details are in the log.",
         "restoreMods": "Ripristina le mod",
         "updateAction": "Aggiorna",
         "updateInstall": "Riavvia e installa",
@@ -151,6 +152,8 @@
         "filterPlaceholder": "Cerca mod...",
         "filterEmpty": "Nessuna mod corrispondente \"{query}\"",
         "reinstallFailed": "Reinstallazione fallita: {error}",
+        "actionFailed": "! {name} could not be changed: {error}",
+        "actionFailedSome": "! {count} mods could not be changed ({names}): {error}",
         "updatesAvailable": "{count} mod possono essere aggiornate",
         "updatesAvailableSingle": "{count} mod può essere aggiornata",
         "reviewUpdates": "Visualizza gli aggiornamenti",

--- a/apps/desktop/src/renderer/src/i18n/it.json
+++ b/apps/desktop/src/renderer/src/i18n/it.json
@@ -154,6 +154,7 @@
         "reinstallFailed": "Reinstallazione fallita: {error}",
         "actionFailed": "! {name} could not be changed: {error}",
         "actionFailedSome": "! {count} mods could not be changed ({names}): {error}",
+        "refreshFailed": "! The installed mod list could not be refreshed: {error}",
         "updatesAvailable": "{count} mod possono essere aggiornate",
         "updatesAvailableSingle": "{count} mod può essere aggiornata",
         "reviewUpdates": "Visualizza gli aggiornamenti",

--- a/apps/desktop/src/renderer/src/i18n/ru.json
+++ b/apps/desktop/src/renderer/src/i18n/ru.json
@@ -154,6 +154,7 @@
         "reinstallFailed": "Не удалось переустановить: {error}",
         "actionFailed": "! {name} could not be changed: {error}",
         "actionFailedSome": "! {count} mods could not be changed ({names}): {error}",
+        "refreshFailed": "! The installed mod list could not be refreshed: {error}",
         "updatesAvailable": "Доступны обновления для {count} модов",
         "updatesAvailableSingle": "Доступно обновление для {count} мода",
         "reviewUpdates": "Просмотреть обновления",

--- a/apps/desktop/src/renderer/src/i18n/ru.json
+++ b/apps/desktop/src/renderer/src/i18n/ru.json
@@ -26,6 +26,7 @@
     },
     "app": {
         "modsHidden": "Моды скрыты — игра была запущена без модов и, возможно, ещё работает.",
+        "stateUnreadable": "! Modrex could not read its own mod list for this game, so the mods below were found by scanning the folder and no changes are being saved. Details are in the log.",
         "restoreMods": "Восстановить моды",
         "updateAction": "Обновить",
         "updateInstall": "Перезапустить и установить",
@@ -151,6 +152,8 @@
         "filterPlaceholder": "Поиск модов…",
         "filterEmpty": "Нет модов, соответствующих запросу «{query}»",
         "reinstallFailed": "Не удалось переустановить: {error}",
+        "actionFailed": "! {name} could not be changed: {error}",
+        "actionFailedSome": "! {count} mods could not be changed ({names}): {error}",
         "updatesAvailable": "Доступны обновления для {count} модов",
         "updatesAvailableSingle": "Доступно обновление для {count} мода",
         "reviewUpdates": "Просмотреть обновления",

--- a/apps/desktop/src/renderer/src/i18n/uk.json
+++ b/apps/desktop/src/renderer/src/i18n/uk.json
@@ -154,6 +154,7 @@
         "reinstallFailed": "Не вдалося перевстановити: {error}",
         "actionFailed": "! {name} could not be changed: {error}",
         "actionFailedSome": "! {count} mods could not be changed ({names}): {error}",
+        "refreshFailed": "! The installed mod list could not be refreshed: {error}",
         "updatesAvailable": "Можна оновити {count} модів",
         "updatesAvailableSingle": "Можна оновити {count} мод",
         "reviewUpdates": "Переглянути оновлення",

--- a/apps/desktop/src/renderer/src/i18n/uk.json
+++ b/apps/desktop/src/renderer/src/i18n/uk.json
@@ -26,6 +26,7 @@
     },
     "app": {
         "modsHidden": "Моди приховано — гру було запущено без модів, і вона досі може працювати.",
+        "stateUnreadable": "! Modrex could not read its own mod list for this game, so the mods below were found by scanning the folder and no changes are being saved. Details are in the log.",
         "restoreMods": "Відновити моди",
         "updateAction": "Оновити",
         "updateInstall": "Перезапустити й установити",
@@ -151,6 +152,8 @@
         "filterPlaceholder": "Шукати моди…",
         "filterEmpty": "Жоден мод не відповідає запиту «{query}»",
         "reinstallFailed": "Не вдалося перевстановити: {error}",
+        "actionFailed": "! {name} could not be changed: {error}",
+        "actionFailedSome": "! {count} mods could not be changed ({names}): {error}",
         "updatesAvailable": "Можна оновити {count} модів",
         "updatesAvailableSingle": "Можна оновити {count} мод",
         "reviewUpdates": "Переглянути оновлення",

--- a/apps/desktop/src/renderer/src/i18n/zh-CN.json
+++ b/apps/desktop/src/renderer/src/i18n/zh-CN.json
@@ -26,6 +26,7 @@
     },
     "app": {
         "modsHidden": "模组已隐藏；游戏以原版模式启动，并且可能仍在运行。",
+        "stateUnreadable": "! Modrex could not read its own mod list for this game, so the mods below were found by scanning the folder and no changes are being saved. Details are in the log.",
         "restoreMods": "恢复模组",
         "updateAction": "更新",
         "updateInstall": "重启并安装",
@@ -151,6 +152,8 @@
         "filterPlaceholder": "搜索模组...",
         "filterEmpty": "没有与“{query}”匹配的模组",
         "reinstallFailed": "重新安装失败：{error}",
+        "actionFailed": "! {name} could not be changed: {error}",
+        "actionFailedSome": "! {count} mods could not be changed ({names}): {error}",
         "updatesAvailable": "有 {count} 个模组可更新",
         "updatesAvailableSingle": "有 {count} 个模组可更新",
         "reviewUpdates": "查看更新",

--- a/apps/desktop/src/renderer/src/i18n/zh-CN.json
+++ b/apps/desktop/src/renderer/src/i18n/zh-CN.json
@@ -154,6 +154,7 @@
         "reinstallFailed": "重新安装失败：{error}",
         "actionFailed": "! {name} could not be changed: {error}",
         "actionFailedSome": "! {count} mods could not be changed ({names}): {error}",
+        "refreshFailed": "! The installed mod list could not be refreshed: {error}",
         "updatesAvailable": "有 {count} 个模组可更新",
         "updatesAvailableSingle": "有 {count} 个模组可更新",
         "reviewUpdates": "查看更新",

--- a/apps/desktop/src/shared/bindings.ts
+++ b/apps/desktop/src/shared/bindings.ts
@@ -520,12 +520,26 @@ export type InstalledResponse_Deserialize = {
 	mods: InstalledMod_Deserialize[],
 	folders: ModFolder[],
 	modsHidden: boolean,
+	/**
+	 *  The mod list on disk could not be loaded, so this response was rebuilt from a scan and
+	 *  nothing was written back. Everything shown is real, but Modrex's own record of folders,
+	 *  order and per-mod metadata is not in it, and no operation may replace that record until
+	 *  the file is readable again.
+	 */
+	stateUnreadable: boolean,
 };
 
 export type InstalledResponse_Serialize = {
 	mods: InstalledMod_Serialize[],
 	folders: ModFolder[],
 	modsHidden: boolean,
+	/**
+	 *  The mod list on disk could not be loaded, so this response was rebuilt from a scan and
+	 *  nothing was written back. Everything shown is real, but Modrex's own record of folders,
+	 *  order and per-mod metadata is not in it, and no operation may replace that record until
+	 *  the file is readable again.
+	 */
+	stateUnreadable: boolean,
 };
 
 export type InstructsTemplate = {

--- a/assets/i18n/status/de.svg
+++ b/assets/i18n/status/de.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="168" height="10" viewBox="0 0 168 10" role="img" aria-label="de translation status">
-<rect x="0" y="0" width="166.902" height="10" fill="#2DA44E"/><rect x="166.902" y="0" width="1.098" height="10" fill="#C94A4A"/>
+<rect x="0" y="0" width="166.539" height="10" fill="#2DA44E"/><rect x="166.539" y="0" width="1.461" height="10" fill="#C94A4A"/>
 </svg>

--- a/assets/i18n/status/de.svg
+++ b/assets/i18n/status/de.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="168" height="10" viewBox="0 0 168 10" role="img" aria-label="de translation status">
-<rect x="0" y="0" width="168" height="10" fill="#2DA44E"/>
+<rect x="0" y="0" width="166.902" height="10" fill="#2DA44E"/><rect x="166.902" y="0" width="1.098" height="10" fill="#C94A4A"/>
 </svg>

--- a/assets/i18n/status/it.svg
+++ b/assets/i18n/status/it.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="168" height="10" viewBox="0 0 168 10" role="img" aria-label="it translation status">
-<rect x="0" y="0" width="156.211" height="10" fill="#2DA44E"/><rect x="156.211" y="0" width="11.789" height="10" fill="#C94A4A"/>
+<rect x="0" y="0" width="155.19" height="10" fill="#2DA44E"/><rect x="155.19" y="0" width="12.81" height="10" fill="#C94A4A"/>
 </svg>

--- a/assets/i18n/status/it.svg
+++ b/assets/i18n/status/it.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="168" height="10" viewBox="0 0 168 10" role="img" aria-label="it translation status">
-<rect x="0" y="0" width="155.19" height="10" fill="#2DA44E"/><rect x="155.19" y="0" width="12.81" height="10" fill="#C94A4A"/>
+<rect x="0" y="0" width="154.852" height="10" fill="#2DA44E"/><rect x="154.852" y="0" width="13.148" height="10" fill="#C94A4A"/>
 </svg>

--- a/assets/i18n/status/ru.svg
+++ b/assets/i18n/status/ru.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="168" height="10" viewBox="0 0 168 10" role="img" aria-label="ru translation status">
-<rect x="0" y="0" width="156.211" height="10" fill="#2DA44E"/><rect x="156.211" y="0" width="11.789" height="10" fill="#C94A4A"/>
+<rect x="0" y="0" width="155.19" height="10" fill="#2DA44E"/><rect x="155.19" y="0" width="12.81" height="10" fill="#C94A4A"/>
 </svg>

--- a/assets/i18n/status/ru.svg
+++ b/assets/i18n/status/ru.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="168" height="10" viewBox="0 0 168 10" role="img" aria-label="ru translation status">
-<rect x="0" y="0" width="155.19" height="10" fill="#2DA44E"/><rect x="155.19" y="0" width="12.81" height="10" fill="#C94A4A"/>
+<rect x="0" y="0" width="154.852" height="10" fill="#2DA44E"/><rect x="154.852" y="0" width="13.148" height="10" fill="#C94A4A"/>
 </svg>

--- a/assets/i18n/status/uk.svg
+++ b/assets/i18n/status/uk.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="168" height="10" viewBox="0 0 168 10" role="img" aria-label="uk translation status">
-<rect x="0" y="0" width="155.19" height="10" fill="#2DA44E"/><rect x="155.19" y="0" width="12.81" height="10" fill="#C94A4A"/>
+<rect x="0" y="0" width="154.852" height="10" fill="#2DA44E"/><rect x="154.852" y="0" width="13.148" height="10" fill="#C94A4A"/>
 </svg>

--- a/assets/i18n/status/uk.svg
+++ b/assets/i18n/status/uk.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="168" height="10" viewBox="0 0 168 10" role="img" aria-label="uk translation status">
-<rect x="0" y="0" width="156.211" height="10" fill="#2DA44E"/><rect x="156.211" y="0" width="11.789" height="10" fill="#C94A4A"/>
+<rect x="0" y="0" width="155.19" height="10" fill="#2DA44E"/><rect x="155.19" y="0" width="12.81" height="10" fill="#C94A4A"/>
 </svg>

--- a/assets/i18n/status/zh-CN.svg
+++ b/assets/i18n/status/zh-CN.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="168" height="10" viewBox="0 0 168 10" role="img" aria-label="zh-CN translation status">
-<rect x="0" y="0" width="166.902" height="10" fill="#2DA44E"/><rect x="166.902" y="0" width="1.098" height="10" fill="#C94A4A"/>
+<rect x="0" y="0" width="166.539" height="10" fill="#2DA44E"/><rect x="166.539" y="0" width="1.461" height="10" fill="#C94A4A"/>
 </svg>

--- a/assets/i18n/status/zh-CN.svg
+++ b/assets/i18n/status/zh-CN.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="168" height="10" viewBox="0 0 168 10" role="img" aria-label="zh-CN translation status">
-<rect x="0" y="0" width="168" height="10" fill="#2DA44E"/>
+<rect x="0" y="0" width="166.902" height="10" fill="#2DA44E"/><rect x="166.902" y="0" width="1.098" height="10" fill="#C94A4A"/>
 </svg>


### PR DESCRIPTION
## Summary

Enabling, disabling and saving mod state could report success when the filesystem disagreed. This makes those failures explicit instead of letting the recorded state and the disk silently diverge.

- Missing, unreadable and invalid `.modrex.json` are now distinguished, and a degraded scan can no longer overwrite state it failed to read.
- A pak and its `.ucas` and `.utoc` companions move as one unit, with rollback if any of them fails.
- Activation is recorded only after the move succeeds, and a failed save reverses only the moves that actually happened.
- Backend failures reach the renderer, bulk actions attempt every mod and report the failures together, and a failed refresh no longer leaves an action stuck loading.

All three fixed behaviours shipped in 0.14.0, verified against the `v0.14.0` tag.

Worth a close look: `read_state` error classification, the `Writeback` capability that gates every `get_installed` writeback, File versus Directory placement observation, sidecar rollback ordering, and the Crime Boss settings reversal.

## Type of change

- [x] Application/code
- [ ] Translation
- [ ] Documentation
- [ ] Other

## Translation (if applicable)

- **Language:**
- **Locale code:**

See the [translation guide](https://github.com/modrexio/modrex/blob/main/TRANSLATING.md).

## Validation

- [x] Full local repository checks (`pnpm checks`)
- [ ] Relevant local checks
- [ ] CI only
- [ ] Not applicable

**Details:**

- `pnpm checks` exit 0. Rust 656 + 2 + 1 + 31 passed, renderer 317, site 28.
- `cargo fmt --all --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `cargo audit` run from `apps/desktop/src-tauri` so `.cargo/audit.toml` applies, exit 0.
- No dependency changes, so `THIRD_PARTY_LICENSES.md` did not need regenerating.
- One new English key, `installed.refreshFailed`, scaffolded into the other locales by `pnpm i18n:sync`. No target-language text was authored.
- The new protections were mutation-tested. Removing refresh handling, writeback blocking, failure precedence or the Crime Boss ordering each fails its regression test.
