### PR TITLE
chore(desktop): translate Russian/Ukrainian strings

### DIFF
--- a/apps/desktop/src/renderer/src/i18n/de.json
+++ b/apps/desktop/src/renderer/src/i18n/de.json
@@ -5,7 +5,7 @@
         "nonPakWarning": "Nicht unterstütztes Format",
         "openLink": "Link öffnen",
         "installing": "Installation",
-        "downloading": "Herunterladen…",
+        "downloading": "Herunterladen...",
         "installed": "Installiert",
         "remove": "Deinstallieren",
         "fileMissing": "Fehlende Datei",
@@ -14,7 +14,7 @@
         "depNeedsManualInstall": "Der Download dieser Abhängigkeit hat eine Auswahl, Öffne die Seiter der Abhängigkeit und lade es herunter.",
         "fix": "Reparieren",
         "reinstall": "Neu-installieren",
-        "loading": "Laden…",
+        "loading": "Laden...",
         "cancel": "Abbrechen",
         "close": "Schließen",
         "dontShowAgain": "Nicht nochmal anzeigen",
@@ -86,7 +86,7 @@
         "title": "Spiele",
         "installedOnly": "Nur installierte",
         "searchLabel": "Durchsuche Spiele",
-        "searchPlaceholder": "Durchsuche alle Spiele…",
+        "searchPlaceholder": "Durchsuche alle Spiele...",
         "noMatches": "Keine Spiele entdeckt"
     },
     "browse": {
@@ -97,7 +97,7 @@
         "allCategories": "Alle Kategorien",
         "tags": "Tags",
         "tagsCount": "Tags ({count})",
-        "tagFilterSearch": "Tags filtern…",
+        "tagFilterSearch": "Tags filtern...",
         "tagFilterClear": "Leeren",
         "tagFilterEmpty": "Keine Tags gefunden",
         "noMods": "Keine Mods gefunden",
@@ -113,7 +113,7 @@
         }
     },
     "nexus": {
-        "searchPlaceholder": "Mods durchsuchen…",
+        "searchPlaceholder": "Mods durchsuchen...",
         "noMods": "Keine Mods gefunden",
         "loadFailed": "Mods konnten nicht geladen werden",
         "modCount": "{total} Mods",
@@ -130,7 +130,7 @@
     "nexusSession": {
         "expired": "Deine Nexus Mods-Anmeldung ist abgelaufen. Das Durchsuchen, Installieren und Suchen nach Updates für Nexus-Mods ist pausiert, bis du dich wieder anmeldest.",
         "signIn": "Erneut anmelden",
-        "awaiting": "Warte auf Browser…",
+        "awaiting": "Warte auf Browser...",
         "failed": "Nexus Mods-Anmeldung fehlgeschlagen: {error}"
     },
     "installed": {
@@ -142,8 +142,8 @@
         "modCountSingle": "{count} Mod",
         "modCountFiltered": "{count} von {total} Mods",
         "empty": "Noch keine Mods installiert",
-        "identifyingNew": "Identifiziere {count} neue Mods…",
-        "filterPlaceholder": "Mods durchsuchen…",
+        "identifyingNew": "Identifiziere {count} neue Mods...",
+        "filterPlaceholder": "Mods durchsuchen...",
         "filterEmpty": "Keine Mods stimmen mit „{query}“ überein",
         "reinstallFailed": "Erneute Installation fehlgeschlagen: {error}",
         "actionFailed": "{name} konnte nicht geändert werden: {error}",
@@ -169,7 +169,7 @@
         },
         "fileCount": "{count} Dateien",
         "manageFiles": {
-            "searchPlaceholder": "Dateien durchsuchen…",
+            "searchPlaceholder": "Dateien durchsuchen...",
             "enableAll": "Alle aktivieren",
             "disableAll": "Alle deaktivieren",
             "noMatches": "Keine Dateien stimmen mit „{query}“ überein",
@@ -180,7 +180,7 @@
         "updatesModal": {
             "title": "Verfügbare Updates ({count})",
             "update": "Aktualisieren",
-            "updating": "Aktualisiere…",
+            "updating": "Aktualisiere...",
             "updatingProgress": "Aktualisiere {done} / {total}",
             "updateSelected": "Ausgewählte aktualisieren ({count})",
             "error": "Aktualisierung fehlgeschlagen. Überprüfe deine Verbindung und versuche es erneut."
@@ -203,7 +203,7 @@
             "identify": "Identifizieren"
         },
         "identifyNexus": {
-            "identifying": "Identifiziere…",
+            "identifying": "Identifiziere...",
             "identified": "Als „{name}“ identifiziert",
             "notFound": "Keine Übereinstimmung auf Nexus gefunden",
             "ambiguous": "Mehrere mögliche Übereinstimmungen auf Nexus gefunden",
@@ -221,7 +221,7 @@
             "confirmTitleToModkit": "Zu Mods/ verschieben?",
             "confirmBodyToModkit": "Verschiebt „{name}“ nach Mods/, wo es sich mit Inhalten anderer Mods zusammenfügen kann.",
             "confirm": "Verschieben",
-            "moving": "Verschiebe…",
+            "moving": "Verschiebe...",
             "error": "Verschieben fehlgeschlagen: {error}"
         },
         "health": {
@@ -306,7 +306,7 @@
             "external": "Herunterladen",
             "count": "{count} DL",
             "viaNexus": "Über Nexus herunterladen",
-            "awaitingNexus": "Warte auf Browser…",
+            "awaitingNexus": "Warte auf Browser...",
             "categoryMain": "Hauptdateien",
             "categoryUpdate": "Updates",
             "categoryOptional": "Optionale Dateien",
@@ -349,7 +349,7 @@
         "requiresHost": "Dieses Add-on wird in {hostName} installiert, welches noch nicht installiert ist. Installiere es zuerst und installiere dann dieses Add-on.",
         "installHost": "{hostName} installieren",
         "install": "Installieren ({count})",
-        "installing": "Installiere…"
+        "installing": "Installiere..."
     },
     "unrecognized": {
         "title": "Diese Mod konnte nicht platziert werden",
@@ -360,7 +360,7 @@
         "title": "Als Mod-Ordner installieren?",
         "body": "Dieses Archiv hat keinen eigenen umschließenden Ordner, daher kann Modrex keinen Mod-Namen automatisch erkennen. Den gesamten Inhalt als „{name}“ unter CrimeBoss/Mods installieren?",
         "install": "Installieren",
-        "installing": "Installiere…"
+        "installing": "Installiere..."
     },
     "ue4ssReplace": {
         "title": "! Replace the installed UE4SS?",
@@ -394,7 +394,7 @@
         "body": "Mods/ wird mit Inhalten anderer Mods zusammengefügt. ~mods ist das ältere Format ohne Zusammenführung.",
         "auto": "Mods/ (ModKit)",
         "legacy": "~mods (Legacy-Pak)",
-        "installing": "Installiere…",
+        "installing": "Installiere...",
         "error": "Installation fehlgeschlagen: {error}"
     },
     "settings": {
@@ -417,11 +417,11 @@
             "title": "Spielpfad",
             "description": "Pfad zu deiner {game}-Installation. Wird automatisch von deinen installierten Launchern erkannt, falls nicht manuell festgelegt.",
             "notFound": "Nicht gefunden",
-            "detecting": "Erkenne…",
+            "detecting": "Erkenne...",
             "reset": "Zurücksetzen",
             "browse": "Durchsuchen",
             "pickTitle": "{game}-Installationsordner auswählen",
-            "picking": "Wähle aus…",
+            "picking": "Wähle aus...",
             "autoDetected": "Automatisch erkannt",
             "notDetected": "{game}-Installation konnte nicht erkannt werden – lege den Pfad manuell fest.",
             "invalid": "Der ausgewählte Ordner ist keine gültige {game}-Installation."
@@ -429,7 +429,7 @@
         "launcher": {
             "title": "Launcher",
             "description": "Wie {game} gestartet wird. Wird automatisch von deinen installierten Stores erkannt.",
-            "detecting": "Erkenne…",
+            "detecting": "Erkenne...",
             "steam": "Steam",
             "epic": "Epic Games",
             "xbox": "Xbox",
@@ -460,7 +460,7 @@
         "updates": {
             "title": "Updates",
             "check": "Nach Updates suchen",
-            "checking": "Suche…",
+            "checking": "Suche...",
             "upToDate": "Du bist auf dem neuesten Stand"
         },
         "logs": {
@@ -498,7 +498,7 @@
             "title": "Speicher",
             "dangerZone": "Gefahrenzone",
             "dangerZoneDescription": "Diese Aktionen löschen lokal gespeicherte Daten. Caches geben Speicherplatz frei und werden bei der Nutzung der App automatisch neu aufgebaut; das Zurücksetzen stellt die Standardeinstellungen wieder her. Keine davon löscht deine installierten Mods oder Spieldateien.",
-            "clearing": "Leere…",
+            "clearing": "Leere...",
             "clearImages": "Bilder löschen",
             "clearModInfo": "Mod-Info löschen",
             "clearDatabase": "Datenbank löschen",
@@ -524,7 +524,7 @@
             "resetConfirmTitle": "Einstellungen zurücksetzen?",
             "resetConfirmBody": "Dies löscht deine gespeicherten Spielpfade, Launcher-Auswahlen, Einstellungen und die Analytik-Auswahl und versetzt Modrex in den Erststart-Zustand zurück. Deine installierten Mods und Spieldateien sind davon nicht betroffen.",
             "resetConfirm": "Einstellungen zurücksetzen",
-            "resetting": "Setze zurück…"
+            "resetting": "Setze zurück..."
         },
         "crimeBossInstallMode": {
             "title": "Neue Mod-Installationen",
@@ -579,8 +579,8 @@
     "drop": {
         "overlayTitle": "Zum Installieren ablegen",
         "overlaySubtitle": "Loslassen, um in {game} zu installieren",
-        "installing": "Installiere…",
-        "installingCount": "Installiere {current} von {total}…",
+        "installing": "Installiere...",
+        "installingCount": "Installiere {current} von {total}...",
         "installed": "{count} Mods installiert",
         "installedSingle": "1 Mod installiert",
         "needsPicker": "Einige Archive müssen vorerst über ihre Mod-Seite installiert werden",

--- a/apps/desktop/src/renderer/src/i18n/ru.json
+++ b/apps/desktop/src/renderer/src/i18n/ru.json
@@ -4,8 +4,8 @@
         "install": "Установить",
         "nonPakWarning": "Неподдерживаемый формат",
         "openLink": "Открыть ссылку",
-        "installing": "Установка…",
-        "downloading": "Загрузка…",
+        "installing": "Установка...",
+        "downloading": "Загрузка...",
         "installed": "Установлено",
         "remove": "Удалить",
         "fileMissing": "Файл отсутствует",
@@ -14,7 +14,7 @@
         "depNeedsManualInstall": "Для загрузки этой зависимости нужно сделать выбор. Откройте страницу мода, чтобы установить её.",
         "fix": "Исправить",
         "reinstall": "Переустановить",
-        "loading": "Загрузка…",
+        "loading": "Загрузка...",
         "cancel": "Отмена",
         "close": "Закрыть",
         "dontShowAgain": "Больше не показывать",
@@ -86,18 +86,18 @@
         "title": "Игры",
         "installedOnly": "Только установленные",
         "searchLabel": "Поиск игр",
-        "searchPlaceholder": "Поиск игр…",
+        "searchPlaceholder": "Поиск игр...",
         "noMatches": "Игры не найдены"
     },
     "browse": {
         "title": "Просмотр модов",
         "gameNotFound": "Игра не найдена — установка отключена",
         "goToSettings": "Настроить в настройках",
-        "searchPlaceholder": "Поиск модов…",
+        "searchPlaceholder": "Поиск модов...",
         "allCategories": "Все категории",
         "tags": "Теги",
         "tagsCount": "Теги ({count})",
-        "tagFilterSearch": "Фильтр тегов…",
+        "tagFilterSearch": "Фильтр тегов...",
         "tagFilterClear": "Очистить",
         "tagFilterEmpty": "Теги не найдены",
         "noMods": "Моды не найдены",
@@ -113,7 +113,7 @@
         }
     },
     "nexus": {
-        "searchPlaceholder": "Поиск модов…",
+        "searchPlaceholder": "Поиск модов...",
         "noMods": "Моды не найдены",
         "loadFailed": "Не удалось загрузить моды",
         "modCount": "{total} модов",
@@ -130,7 +130,7 @@
     "nexusSession": {
         "expired": "Срок действия входа в Nexus Mods истёк. Просмотр, установка и проверка обновлений модов с Nexus приостановлены, пока вы не войдёте снова.",
         "signIn": "Войти снова",
-        "awaiting": "Ожидание браузера…",
+        "awaiting": "Ожидание браузера...",
         "failed": "Не удалось войти в Nexus Mods: {error}"
     },
     "installed": {
@@ -142,8 +142,8 @@
         "modCountSingle": "{count} мод",
         "modCountFiltered": "{count} из {total} модов",
         "empty": "Моды пока не установлены",
-        "identifyingNew": "Определение {count} новых модов…",
-        "filterPlaceholder": "Поиск модов…",
+        "identifyingNew": "Определение {count} новых модов...",
+        "filterPlaceholder": "Поиск модов...",
         "filterEmpty": "Нет модов, соответствующих запросу «{query}»",
         "reinstallFailed": "Не удалось переустановить: {error}",
         "actionFailed": "Не удалось изменить «{name}»: {error}",
@@ -169,7 +169,7 @@
         },
         "fileCount": "{count} файлов",
         "manageFiles": {
-            "searchPlaceholder": "Поиск файлов…",
+            "searchPlaceholder": "Поиск файлов...",
             "enableAll": "Включить все",
             "disableAll": "Отключить все",
             "noMatches": "Нет файлов, соответствующих запросу «{query}»",
@@ -180,7 +180,7 @@
         "updatesModal": {
             "title": "Доступные обновления ({count})",
             "update": "Обновить",
-            "updating": "Обновление…",
+            "updating": "Обновление...",
             "updatingProgress": "Обновление {done} / {total}",
             "updateSelected": "Обновить выбранное ({count})",
             "error": "Не удалось обновить. Проверьте подключение и повторите попытку."
@@ -188,10 +188,10 @@
         "pakViewer": {
             "title": "Содержимое pak-файла",
             "open": "Просмотреть содержимое pak-файла",
-            "searchPlaceholder": "Поиск ассетов…",
+            "searchPlaceholder": "Поиск ассетов...",
             "assetCount": "{count} ассетов",
             "matchCount": "{count} из {total} ассетов",
-            "loading": "Чтение pak-файла…",
+            "loading": "Чтение pak-файла...",
             "empty": "Ассеты не найдены",
             "noMatches": "Нет ассетов, соответствующих запросу «{query}»",
             "error": "Не удалось прочитать pak-файл.",
@@ -203,7 +203,7 @@
             "identify": "Определить"
         },
         "identifyNexus": {
-            "identifying": "Определение…",
+            "identifying": "Определение...",
             "identified": "Определено как «{name}»",
             "notFound": "Совпадений на Nexus не найдено",
             "ambiguous": "На Nexus найдено несколько возможных совпадений",
@@ -221,7 +221,7 @@
             "confirmTitleToModkit": "Переместить в Mods/?",
             "confirmBodyToModkit": "Перемещает «{name}» в Mods/, где он сможет объединяться с содержимым других модов.",
             "confirm": "Переместить",
-            "moving": "Перемещение…",
+            "moving": "Перемещение...",
             "error": "Не удалось переместить: {error}"
         },
         "health": {
@@ -306,7 +306,7 @@
             "external": "Скачать",
             "count": "{count} загр.",
             "viaNexus": "Скачать через Nexus",
-            "awaitingNexus": "Ожидание браузера…",
+            "awaitingNexus": "Ожидание браузера...",
             "categoryMain": "Основные файлы",
             "categoryUpdate": "Обновления",
             "categoryOptional": "Дополнительные файлы",
@@ -349,7 +349,7 @@
         "requiresHost": "Это дополнение устанавливается в {hostName}, который ещё не установлен. Сначала установите его, затем это дополнение.",
         "installHost": "Установить {hostName}",
         "install": "Установить ({count})",
-        "installing": "Установка…"
+        "installing": "Установка..."
     },
     "unrecognized": {
         "title": "Не удалось определить расположение мода",
@@ -360,7 +360,7 @@
         "title": "Установить как папку мода?",
         "body": "У этого архива нет собственной вложенной папки, поэтому Modrex не может автоматически определить название мода. Установить всё его содержимое как «{name}» в CrimeBoss/Mods?",
         "install": "Установить",
-        "installing": "Установка…"
+        "installing": "Установка..."
     },
     "ue4ssReplace": {
         "title": "Заменить установленный UE4SS?",
@@ -370,7 +370,7 @@
         "nothingOfYours": "В папке Mods загрузчика нет ваших собственных модов.",
         "modsListNote": "Ваши моды сохранят свои записи в списке модов загрузчика.",
         "replace": "Заменить",
-        "replacing": "Замена…"
+        "replacing": "Замена..."
     },
     "ue4ssRemove": {
         "title": "Удалить UE4SS?",
@@ -378,7 +378,7 @@
         "removed": "Удалено",
         "kept": "Оставлено",
         "nothingOfYours": "В папке Mods загрузчика нет ваших собственных модов.",
-        "removing": "Удаление…"
+        "removing": "Удаление..."
     },
     "depsWarning": {
         "title": "Отсутствуют обязательные зависимости",
@@ -394,7 +394,7 @@
         "body": "Mods/ объединяется с содержимым других модов. ~mods — старый формат без объединения.",
         "auto": "Mods/ (ModKit)",
         "legacy": "~mods (устаревший pak)",
-        "installing": "Установка…",
+        "installing": "Установка...",
         "error": "Установка не удалась: {error}"
     },
     "settings": {
@@ -417,11 +417,11 @@
             "title": "Путь к игре",
             "description": "Путь к установленной {game}. Определяется автоматически по установленным лаунчерам, если не задан вручную.",
             "notFound": "Не найдено",
-            "detecting": "Определение…",
+            "detecting": "Определение...",
             "reset": "Сбросить",
             "browse": "Обзор",
             "pickTitle": "Выберите папку установки {game}",
-            "picking": "Выбор…",
+            "picking": "Выбор...",
             "autoDetected": "Определено автоматически",
             "notDetected": "Не удалось определить установку {game} — задайте путь вручную.",
             "invalid": "Выбранная папка не является корректной установкой {game}."
@@ -429,7 +429,7 @@
         "launcher": {
             "title": "Лаунчер",
             "description": "Как запускать {game}. Определяется автоматически по установленным магазинам.",
-            "detecting": "Определение…",
+            "detecting": "Определение...",
             "steam": "Steam",
             "epic": "Epic Games",
             "xbox": "Xbox",
@@ -460,7 +460,7 @@
         "updates": {
             "title": "Обновления",
             "check": "Проверить обновления",
-            "checking": "Проверка…",
+            "checking": "Проверка...",
             "upToDate": "У вас последняя версия"
         },
         "logs": {
@@ -498,7 +498,7 @@
             "title": "Хранилище",
             "dangerZone": "Опасная зона",
             "dangerZoneDescription": "Эти действия удаляют локально хранящиеся данные. Кэши освобождают место на диске и восстанавливаются автоматически при использовании приложения; сброс возвращает настройки по умолчанию. Ни одно из этих действий не затрагивает установленные моды или файлы игры.",
-            "clearing": "Очистка…",
+            "clearing": "Очистка...",
             "clearImages": "Очистить изображения",
             "clearModInfo": "Очистить сведения о модах",
             "clearDatabase": "Очистить базу данных",
@@ -524,7 +524,7 @@
             "resetConfirmTitle": "Сбросить настройки?",
             "resetConfirmBody": "Это очистит сохранённые пути к играм, выбор лаунчера, настройки и выбор в отношении аналитики, вернув Modrex к состоянию первого запуска. Установленные моды и файлы игры не пострадают.",
             "resetConfirm": "Сбросить настройки",
-            "resetting": "Сброс…"
+            "resetting": "Сброс..."
         },
         "crimeBossInstallMode": {
             "title": "Установка новых модов",
@@ -579,8 +579,8 @@
     "drop": {
         "overlayTitle": "Отпустите, чтобы установить",
         "overlaySubtitle": "Отпустите, чтобы установить в {game}",
-        "installing": "Установка…",
-        "installingCount": "Установка {current} из {total}…",
+        "installing": "Установка...",
+        "installingCount": "Установка {current} из {total}...",
         "installed": "Установлено модов: {count}",
         "installedSingle": "Установлен 1 мод",
         "needsPicker": "Некоторые архивы пока можно установить только со страницы мода",

--- a/apps/desktop/src/renderer/src/i18n/ru.json
+++ b/apps/desktop/src/renderer/src/i18n/ru.json
@@ -26,7 +26,7 @@
     },
     "app": {
         "modsHidden": "Моды скрыты — игра была запущена без модов и, возможно, ещё работает.",
-        "stateUnreadable": "! Modrex could not read its own mod list for this game, so the mods below were found by scanning the folder and no changes are being saved. Details are in the log.",
+        "stateUnreadable": "Modrex не смог прочитать список модов для этой игры — моды ниже найдены путём сканирования папки, и изменения не сохраняются. Подробности в файле лога.",
         "restoreMods": "Восстановить моды",
         "updateAction": "Обновить",
         "updateInstall": "Перезапустить и установить",
@@ -60,11 +60,11 @@
         "restore": "Восстановить",
         "close": "Закрыть",
         "sisr": {
-            "unsupported": "! SISR auto-launch is not supported on this operating system. The game was launched without it.",
-            "notInstalled": "! SISR was not found. The game was launched without it.",
-            "setupRequired": "! SISR needs its first-run setup before controller redirection will work. The game was launched anyway.",
-            "startFailed": "! SISR failed to start. The game was launched without it.",
-            "startUnconfirmed": "! Modrex could not confirm that SISR started. The game was launched anyway."
+            "unsupported": "Автозапуск SISR не поддерживается в этой операционной системе. Игра запущена без него.",
+            "notInstalled": "SISR не найден. Игра запущена без него.",
+            "setupRequired": "Перед перенаправлением контроллера нужно выполнить первоначальную настройку SISR. Игра всё равно запущена.",
+            "startFailed": "Не удалось запустить SISR. Игра запущена без него.",
+            "startUnconfirmed": "Modrex не смог подтвердить запуск SISR. Игра всё равно запущена."
         }
     },
     "sidebar": {
@@ -146,9 +146,9 @@
         "filterPlaceholder": "Поиск модов…",
         "filterEmpty": "Нет модов, соответствующих запросу «{query}»",
         "reinstallFailed": "Не удалось переустановить: {error}",
-        "actionFailed": "! {name} could not be changed: {error}",
-        "actionFailedSome": "! {count} mods could not be changed ({names}): {error}",
-        "refreshFailed": "! The installed mod list could not be refreshed: {error}",
+        "actionFailed": "Не удалось изменить «{name}»: {error}",
+        "actionFailedSome": "Не удалось изменить {count} модов ({names}): {error}",
+        "refreshFailed": "Не удалось обновить список установленных модов: {error}",
         "updatesAvailable": "Доступны обновления для {count} модов",
         "updatesAvailableSingle": "Доступно обновление для {count} мода",
         "reviewUpdates": "Просмотреть обновления",
@@ -186,16 +186,16 @@
             "error": "Не удалось обновить. Проверьте подключение и повторите попытку."
         },
         "pakViewer": {
-            "title": "! Pak contents",
-            "open": "! View pak contents",
-            "searchPlaceholder": "! Search assets",
-            "assetCount": "! {count} assets",
-            "matchCount": "! {count} of {total} assets",
-            "loading": "! Reading pak",
-            "empty": "! No assets found",
-            "noMatches": "! No assets match \"{query}\"",
-            "error": "! Couldn't read the pak.",
-            "aesHint": "! Encrypted paks need this game's AES key."
+            "title": "Содержимое pak-файла",
+            "open": "Просмотреть содержимое pak-файла",
+            "searchPlaceholder": "Поиск ассетов…",
+            "assetCount": "{count} ассетов",
+            "matchCount": "{count} из {total} ассетов",
+            "loading": "Чтение pak-файла…",
+            "empty": "Ассеты не найдены",
+            "noMatches": "Нет ассетов, соответствующих запросу «{query}»",
+            "error": "Не удалось прочитать pak-файл.",
+            "aesHint": "Зашифрованным pak-файлам нужен AES-ключ этой игры."
         },
         "modMenu": {
             "open": "Параметры",
@@ -363,22 +363,22 @@
         "installing": "Установка…"
     },
     "ue4ssReplace": {
-        "title": "! Replace the installed UE4SS?",
-        "body": "! {name} replaces the UE4SS that is already installed. The installed release is removed first: the two put their engine and settings in different places, so leaving it in place would load both.",
-        "removed": "! Removed",
-        "kept": "! Kept",
-        "nothingOfYours": "! You have no mods of your own in the loader's Mods folder.",
-        "modsListNote": "! Your own mods keep their entries in the loader's mod list.",
-        "replace": "! Replace",
-        "replacing": "! Replacing..."
+        "title": "Заменить установленный UE4SS?",
+        "body": "«{name}» заменяет уже установленный UE4SS. Установленная версия будет сначала удалена: обе версии хранят движок и настройки в разных местах, поэтому если оставить старую, загрузятся обе.",
+        "removed": "Удалено",
+        "kept": "Оставлено",
+        "nothingOfYours": "В папке Mods загрузчика нет ваших собственных модов.",
+        "modsListNote": "Ваши моды сохранят свои записи в списке модов загрузчика.",
+        "replace": "Заменить",
+        "replacing": "Замена…"
     },
     "ue4ssRemove": {
-        "title": "! Remove UE4SS?",
-        "body": "! UE4SS is what loads Lua mods, so removing it stops them running until you install it again. Only the files it installed are deleted.",
-        "removed": "! Removed",
-        "kept": "! Kept",
-        "nothingOfYours": "! You have no mods of your own in the loader's Mods folder.",
-        "removing": "! Removing..."
+        "title": "Удалить UE4SS?",
+        "body": "UE4SS загружает Lua-моды, поэтому его удаление остановит их работу до повторной установки. Будут удалены только файлы, установленные им самим.",
+        "removed": "Удалено",
+        "kept": "Оставлено",
+        "nothingOfYours": "В папке Mods загрузчика нет ваших собственных модов.",
+        "removing": "Удаление…"
     },
     "depsWarning": {
         "title": "Отсутствуют обязательные зависимости",
@@ -404,14 +404,14 @@
             "description": "Язык, используемый во всём приложении."
         },
         "accentColor": {
-            "title": "! Accent color",
-            "description": "! Accent color used throughout the app.",
-            "orange": "! Orange",
-            "purple": "! Purple",
-            "green": "! Green",
-            "blue": "! Blue",
-            "red": "! Red",
-            "gray": "! Gray"
+            "title": "Акцентный цвет",
+            "description": "Акцентный цвет, используемый во всём приложении.",
+            "orange": "Оранжевый",
+            "purple": "Фиолетовый",
+            "green": "Зелёный",
+            "blue": "Синий",
+            "red": "Красный",
+            "gray": "Серый"
         },
         "gamePath": {
             "title": "Путь к игре",
@@ -439,23 +439,23 @@
         },
         "launchOptions": {
             "title": "Параметры запуска",
-            "description": "! {flag} is needed for most of this game's mods to load correctly.",
-            "xboxNote": "! Launch options are not supported on Microsoft Store."
+            "description": "{flag} требуется для корректной загрузки большинства модов этой игры.",
+            "xboxNote": "Параметры запуска не поддерживаются в Microsoft Store."
         },
         "crashReporter": {
             "title": "Очистка окна сбоев",
             "description": "Устраняет проблему с пустым окном отчёта о сбое для игр с нестабильным механизмом отчётов, удаляя его файлы перед запуском. По умолчанию отключено и может не требоваться для каждой игры."
         },
         "sisr": {
-            "title": "! Auto-launch SISR",
-            "description": "! Start SISR (Steam Input System Redirector) before launching a game when it is not already running, so Steam Input controllers work with games launched outside Steam.",
-            "running": "! SISR is running.",
-            "notRunning": "! SISR is not running. It will start when you launch a game.",
-            "notInstalled": "! SISR was not found in its default installation location.",
-            "setupRequired": "! Complete SISR's first-run Steam setup before using auto-launch.",
-            "setup": "! Set up SISR",
-            "finishSetup": "! Finish setup",
-            "failed": "! SISR setting failed: {error}"
+            "title": "Автозапуск SISR",
+            "description": "Запускать SISR (Steam Input System Redirector) перед игрой, если он ещё не запущен, чтобы контроллеры Steam Input работали в играх, запущенных не через Steam.",
+            "running": "SISR запущен.",
+            "notRunning": "SISR не запущен. Он запустится при запуске игры.",
+            "notInstalled": "SISR не найден в стандартном месте установки.",
+            "setupRequired": "Перед использованием автозапуска завершите первоначальную настройку SISR через Steam.",
+            "setup": "Настроить SISR",
+            "finishSetup": "Завершить настройку",
+            "failed": "Не удалось настроить SISR: {error}"
         },
         "updates": {
             "title": "Обновления",

--- a/apps/desktop/src/renderer/src/i18n/uk.json
+++ b/apps/desktop/src/renderer/src/i18n/uk.json
@@ -4,8 +4,8 @@
         "install": "Встановити",
         "nonPakWarning": "Непідтримуваний формат",
         "openLink": "Відкрити посилання",
-        "installing": "Встановлення…",
-        "downloading": "Завантаження…",
+        "installing": "Встановлення...",
+        "downloading": "Завантаження...",
         "installed": "Встановлено",
         "remove": "Видалити",
         "fileMissing": "Файл відсутній",
@@ -14,7 +14,7 @@
         "depNeedsManualInstall": "Для завантаження цієї залежності потрібно зробити вибір. Відкрийте сторінку мода, щоб встановити її.",
         "fix": "Виправити",
         "reinstall": "Перевстановити",
-        "loading": "Завантаження…",
+        "loading": "Завантаження...",
         "cancel": "Скасувати",
         "close": "Закрити",
         "dontShowAgain": "Більше не показувати",
@@ -47,7 +47,7 @@
     },
     "errorBoundary": {
         "close": "Закрити",
-        "message": "Ой… Щось пішло не так."
+        "message": "Ой... Щось пішло не так."
     },
     "topBar": {
         "title": "Modrex",
@@ -86,18 +86,18 @@
         "title": "Ігри",
         "installedOnly": "Лише встановлені",
         "searchLabel": "Пошук ігор",
-        "searchPlaceholder": "Шукати ігри…",
+        "searchPlaceholder": "Шукати ігри...",
         "noMatches": "Ігор не знайдено"
     },
     "browse": {
         "title": "Огляд модів",
         "gameNotFound": "Гру не знайдено — встановлення вимкнено",
         "goToSettings": "Налаштувати в параметрах",
-        "searchPlaceholder": "Шукати моди…",
+        "searchPlaceholder": "Шукати моди...",
         "allCategories": "Усі категорії",
         "tags": "Теги",
         "tagsCount": "Теги ({count})",
-        "tagFilterSearch": "Фільтрувати теги…",
+        "tagFilterSearch": "Фільтрувати теги...",
         "tagFilterClear": "Очистити",
         "tagFilterEmpty": "Тегів не знайдено",
         "noMods": "Модів не знайдено",
@@ -113,7 +113,7 @@
         }
     },
     "nexus": {
-        "searchPlaceholder": "Шукати моди…",
+        "searchPlaceholder": "Шукати моди...",
         "noMods": "Модів не знайдено",
         "loadFailed": "Не вдалося завантажити моди",
         "modCount": "Модів: {total}",
@@ -130,7 +130,7 @@
     "nexusSession": {
         "expired": "Термін дії вашого входу в Nexus Mods минув. Перегляд, установлення та перевірку оновлень для модів Nexus призупинено, доки ви не ввійдете знову.",
         "signIn": "Увійти знову",
-        "awaiting": "Очікування браузера…",
+        "awaiting": "Очікування браузера...",
         "failed": "Не вдалося ввійти в Nexus Mods: {error}"
     },
     "installed": {
@@ -142,8 +142,8 @@
         "modCountSingle": "{count} мод",
         "modCountFiltered": "Модів: {count} із {total}",
         "empty": "Моди ще не встановлено",
-        "identifyingNew": "Розпізнавання нових модів: {count}…",
-        "filterPlaceholder": "Шукати моди…",
+        "identifyingNew": "Розпізнавання нових модів: {count}...",
+        "filterPlaceholder": "Шукати моди...",
         "filterEmpty": "Жоден мод не відповідає запиту «{query}»",
         "reinstallFailed": "Не вдалося перевстановити: {error}",
         "actionFailed": "Не вдалося змінити «{name}»: {error}",
@@ -169,7 +169,7 @@
         },
         "fileCount": "Файлів: {count}",
         "manageFiles": {
-            "searchPlaceholder": "Шукати файли…",
+            "searchPlaceholder": "Шукати файли...",
             "enableAll": "Увімкнути всі",
             "disableAll": "Вимкнути всі",
             "noMatches": "Жоден файл не відповідає запиту «{query}»",
@@ -180,7 +180,7 @@
         "updatesModal": {
             "title": "Доступні оновлення ({count})",
             "update": "Оновити",
-            "updating": "Оновлення…",
+            "updating": "Оновлення...",
             "updatingProgress": "Оновлення: {done} / {total}",
             "updateSelected": "Оновити вибрані ({count})",
             "error": "Не вдалося оновити. Перевірте з’єднання та повторіть спробу."
@@ -188,10 +188,10 @@
         "pakViewer": {
             "title": "Вміст pak-файлу",
             "open": "Переглянути вміст pak-файлу",
-            "searchPlaceholder": "Шукати ресурси…",
+            "searchPlaceholder": "Шукати ресурси...",
             "assetCount": "Ресурсів: {count}",
             "matchCount": "Ресурсів: {count} із {total}",
-            "loading": "Читання pak-файлу…",
+            "loading": "Читання pak-файлу...",
             "empty": "Ресурсів не знайдено",
             "noMatches": "Жоден ресурс не відповідає запиту «{query}»",
             "error": "Не вдалося прочитати pak-файл.",
@@ -203,7 +203,7 @@
             "identify": "Розпізнати"
         },
         "identifyNexus": {
-            "identifying": "Розпізнавання…",
+            "identifying": "Розпізнавання...",
             "identified": "Розпізнано як «{name}»",
             "notFound": "Збігів на Nexus не знайдено",
             "ambiguous": "На Nexus знайдено кілька можливих збігів",
@@ -221,7 +221,7 @@
             "confirmTitleToModkit": "Перемістити до Mods/?",
             "confirmBodyToModkit": "Переміщує «{name}» до Mods/, де його вміст може об’єднуватися з вмістом інших модів.",
             "confirm": "Перемістити",
-            "moving": "Переміщення…",
+            "moving": "Переміщення...",
             "error": "Не вдалося перемістити: {error}"
         },
         "health": {
@@ -306,7 +306,7 @@
             "external": "Завантажити",
             "count": "Завантажень: {count}",
             "viaNexus": "Завантажити через Nexus",
-            "awaitingNexus": "Очікування браузера…",
+            "awaitingNexus": "Очікування браузера...",
             "categoryMain": "Основні файли",
             "categoryUpdate": "Оновлення",
             "categoryOptional": "Необов’язкові файли",
@@ -349,7 +349,7 @@
         "requiresHost": "Це доповнення встановлюється в {hostName}, який ще не встановлено. Спочатку встановіть його, а потім це доповнення.",
         "installHost": "Встановити {hostName}",
         "install": "Встановити ({count})",
-        "installing": "Встановлення…"
+        "installing": "Встановлення..."
     },
     "unrecognized": {
         "title": "Не вдалося визначити місце мода",
@@ -360,25 +360,25 @@
         "title": "Установити як папку мода?",
         "body": "Цей архів не має власної папки-обгортки, тому Modrex не може автоматично визначити з нього назву мода. Установити весь його вміст як «{name}» у CrimeBoss/Mods?",
         "install": "Встановити",
-        "installing": "Встановлення…"
+        "installing": "Встановлення..."
     },
     "ue4ssReplace": {
-        "title": "! Replace the installed UE4SS?",
-        "body": "! {name} replaces the UE4SS that is already installed. The installed release is removed first: the two put their engine and settings in different places, so leaving it in place would load both.",
-        "removed": "! Removed",
-        "kept": "! Kept",
-        "nothingOfYours": "! You have no mods of your own in the loader's Mods folder.",
-        "modsListNote": "! Your own mods keep their entries in the loader's mod list.",
-        "replace": "! Replace",
-        "replacing": "! Replacing..."
+        "title": "Замінити встановлений UE4SS?",
+        "body": "«{name}» замінює вже встановлений UE4SS. Спочатку буде видалено встановлену версію: обидві зберігають рушій і налаштування в різних місцях, тому якщо залишити стару, завантажаться обидві.",
+        "removed": "Видалено",
+        "kept": "Залишено",
+        "nothingOfYours": "У папці Mods завантажувача немає ваших власних модів.",
+        "modsListNote": "Ваші моди збережуть свої записи в списку модів завантажувача.",
+        "replace": "Замінити",
+        "replacing": "Заміна..."
     },
     "ue4ssRemove": {
-        "title": "! Remove UE4SS?",
-        "body": "! UE4SS is what loads Lua mods, so removing it stops them running until you install it again. Only the files it installed are deleted.",
-        "removed": "! Removed",
-        "kept": "! Kept",
-        "nothingOfYours": "! You have no mods of your own in the loader's Mods folder.",
-        "removing": "! Removing..."
+        "title": "Видалити UE4SS?",
+        "body": "UE4SS завантажує Lua-моди, тому його видалення зупинить їх роботу до повторного встановлення. Буде видалено лише файли, які він сам встановив.",
+        "removed": "Видалено",
+        "kept": "Залишено",
+        "nothingOfYours": "У папці Mods завантажувача немає ваших власних модів.",
+        "removing": "Видалення..."
     },
     "depsWarning": {
         "title": "Відсутні обов’язкові залежності",
@@ -394,7 +394,7 @@
         "body": "Mods/ об’єднує вміст з іншими модами. ~mods — це старіший формат без об’єднання.",
         "auto": "Mods/ (ModKit)",
         "legacy": "~mods (застарілий pak)",
-        "installing": "Встановлення…",
+        "installing": "Встановлення...",
         "error": "Не вдалося встановити: {error}"
     },
     "settings": {
@@ -417,11 +417,11 @@
             "title": "Шлях до гри",
             "description": "Шлях до встановленої гри {game}. Якщо його не вказано вручну, він визначається автоматично за встановленими програмами запуску.",
             "notFound": "Не знайдено",
-            "detecting": "Виявлення…",
+            "detecting": "Виявлення...",
             "reset": "Скинути",
             "browse": "Огляд",
             "pickTitle": "Виберіть папку встановлення {game}",
-            "picking": "Вибір…",
+            "picking": "Вибір...",
             "autoDetected": "Виявлено автоматично",
             "notDetected": "Не вдалося знайти встановлену гру {game} — укажіть шлях вручну.",
             "invalid": "Вибрана папка не є дійсною папкою встановлення {game}."
@@ -429,7 +429,7 @@
         "launcher": {
             "title": "Програма запуску",
             "description": "Спосіб запуску {game}. Визначається автоматично за встановленими магазинами.",
-            "detecting": "Виявлення…",
+            "detecting": "Виявлення...",
             "steam": "Steam",
             "epic": "Epic Games",
             "xbox": "Xbox",
@@ -439,8 +439,8 @@
         },
         "launchOptions": {
             "title": "Параметри запуску",
-            "description": "! {flag} is needed for most of this game's mods to load correctly.",
-            "xboxNote": "! Launch options are not supported on Microsoft Store."
+            "description": "{flag} потрібен для коректного завантаження більшості модів цієї гри.",
+            "xboxNote": "Параметри запуску не підтримуються в Microsoft Store."
         },
         "crashReporter": {
             "title": "Очищення засобу звітування про збої",
@@ -460,7 +460,7 @@
         "updates": {
             "title": "Оновлення",
             "check": "Перевірити оновлення",
-            "checking": "Перевірка…",
+            "checking": "Перевірка...",
             "upToDate": "У вас найновіша версія"
         },
         "logs": {
@@ -498,7 +498,7 @@
             "title": "Сховище",
             "dangerZone": "Небезпечна зона",
             "dangerZoneDescription": "Ці дії видаляють локальні дані. Кеші звільняють місце на диску й автоматично відновлюються під час користування застосунком; скидання відновлює стандартні налаштування. Жодна з цих дій не видаляє встановлені моди чи файли гри.",
-            "clearing": "Очищення…",
+            "clearing": "Очищення...",
             "clearImages": "Очистити зображення",
             "clearModInfo": "Очистити дані модів",
             "clearDatabase": "Очистити базу даних",
@@ -524,7 +524,7 @@
             "resetConfirmTitle": "Скинути налаштування?",
             "resetConfirmBody": "Це очистить збережені шляхи до ігор, вибір програм запуску, уподобання та вибір аналітики, а потім поверне Modrex до стану першого запуску. Встановлені моди й файли ігор не буде змінено.",
             "resetConfirm": "Скинути налаштування",
-            "resetting": "Скидання…"
+            "resetting": "Скидання..."
         },
         "crimeBossInstallMode": {
             "title": "Установлення нових модів",
@@ -579,8 +579,8 @@
     "drop": {
         "overlayTitle": "Відпустіть, щоб установити",
         "overlaySubtitle": "Відпустіть, щоб установити в {game}",
-        "installing": "Встановлення…",
-        "installingCount": "Встановлення: {current} із {total}…",
+        "installing": "Встановлення...",
+        "installingCount": "Встановлення: {current} із {total}...",
         "installed": "Установлено модів: {count}",
         "installedSingle": "Установлено 1 мод",
         "needsPicker": "Деякі архіви наразі можна встановити лише зі сторінки мода",


### PR DESCRIPTION
## Summary

Fills remaining Russian and Ukrainian translations and normalizes the U+2026 ellipsis to ASCII `...` in de/ru/uk locales.

## Type of change

- [ ] Application/code
- [x] Translation
- [ ] Documentation
- [ ] Other

## Translation (if applicable)

- **Language:** Russian, Ukrainian
- **Locale code:** ru, uk

See the [translation guide](https://github.com/modrexio/modrex/blob/main/TRANSLATING.md).

## Validation

- [ ] Full local repository checks (`pnpm checks`)
- [x] Relevant local checks
- [ ] CI only
- [ ] Not applicable

**Details:**

`pnpm i18n:check ru`, `pnpm i18n:check uk`: 100% coverage, valid.